### PR TITLE
docs: add AI doc contracts for issue #33

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Chinese docs are the source of truth for this site; English pages are maintained mirrors and must be updated in the same change
 - The canonical local commands are `npm run lint`, `npm run build`, and `npm run typecheck`
 - Use Playwright or equivalent product verification only when text inspection of `../tiangong-lca-next` is not enough to confirm the current UI flow or screenshot target

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,206 +1,97 @@
-# AGENTS - Tiangong LCA Next Docs
+---
+title: next-docs AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: next-docs
+language: en
+whenToUse:
+  - when a task may change public Docusaurus documentation, site navigation, screenshots, or docs-product drift tracking
+  - when deciding whether work belongs in this repository, in tiangong-lca-next, or in lca-workspace
+  - when routing from the workspace root into tiangong-lca-next-docs
+whenToUpdate:
+  - when product/docs ownership boundaries change
+  - when the bilingual public-doc workflow changes
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - TODO.docs-system-gaps.md
+  - ai/**/*.yaml
+  - docs/**
+  - i18n/en/docusaurus-plugin-content-docs/current/**
+  - sidebars.ts
+  - docusaurus.config.ts
+  - src/**
+  - static/**
+  - package.json
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 5c945a72f0847e9c27f56a38eb9aca7389f69fa9
+related:
+  - ai/repo.yaml
+  - ai/doc-impact.yaml
+  - README.md
+  - TODO.docs-system-gaps.md
+---
 
-Use this file as the single entry point for AI agents working in this repository.
+## Repo Contract
 
-## Repo Purpose
+`tiangong-lca-next-docs` owns the public TianGong LCA documentation site built with Docusaurus. Start here when the task may change published docs pages, navigation, screenshots, or the durable backlog that tracks docs drift against the product.
 
-- This repository publishes the public TianGong LCA documentation site with Docusaurus.
-- The primary product counterpart is `../tiangong-lca-next`.
-- This repo is manually synchronized with the product repo. There is no automatic docs generation
-  from product code, routes, or UI labels.
+## AI Load Order
 
-## Runtime Baseline
+Load docs in this order:
 
-- Node.js `>=18.0` per `package.json`.
-- Stack: Docusaurus 3 + React 19 + TypeScript.
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/doc-impact.yaml`
+4. `README.md` for maintainer workflow details
+5. `TODO.docs-system-gaps.md` when the task is part of an existing drift item
+6. the target page under `docs/**` and its English mirror under `i18n/en/docusaurus-plugin-content-docs/current/**`
 
-Core commands:
+Do not start by guessing product behavior from the docs repo alone.
 
-```bash
-npm install
-npm run start
-npm run build
-npm run lint
-npm run typecheck
-```
+## Repo Ownership
 
-Notes:
+This repo owns:
 
-- `npm run lint` runs `markdownlint-cli2` across all Markdown files in the repo.
-- `npm run build` should be used when changing Docusaurus config, sidebars, MDX, routes, or locale
-  structure.
-- Avoid bulk translation regeneration unless explicitly needed; `write-translations` can create noisy
-  diffs and does not replace manual review.
+- `docs/**` as the canonical Chinese public-doc source
+- `i18n/en/docusaurus-plugin-content-docs/current/**` as the maintained English mirror
+- `sidebars.ts`, `docusaurus.config.ts`, `src/**`, and `static/**` for docs-site structure and presentation
+- `TODO.docs-system-gaps.md` for durable tracking of product/docs drift
 
-## Repo Landmarks
+This repo does not own:
 
-- `docs/**`: Chinese public docs source files.
-- `i18n/en/docusaurus-plugin-content-docs/current/**`: English public docs mirror.
-- `sidebars.ts`: public navigation structure.
-- `docusaurus.config.ts`: site config, locales, navbar, footer, and search.
-- `static/**`: site assets.
-- `README.md`: maintainer-facing repo usage notes.
-- `TODO.docs-system-gaps.md`: internal backlog for product/docs drift. Keep durable gap tracking here.
+- shipped product behavior
+- product routes, API semantics, or hidden-role UI logic
+- workspace integration state after merge
 
-## Online Verification Environment
+Route those tasks to:
 
-- Online system URL: `https://lca.tiangong.earth/`
-- `../tiangong-lca-next` is published directly from its `main` branch.
-- Because of that release model, docs work does not need a separate “is online consistent with
-  `main`?” verification step unless a maintainer explicitly suspects deployment drift or outage.
-- Local credentials and tokens for verification may exist in the repo-root `.env` file.
-- Expected variable names:
-  - `TIANGONG_LCA_USERNAME`
-  - `TIANGONG_LCA_PASSWORD`
-  - `TIANGONG_LCA_API_KEY`
+- `tiangong-lca-next` for shipped product behavior and UI truth
+- `lca-workspace` for root integration after merge
 
-Hard rules:
+## Runtime Facts
 
-- Never paste secret values into docs, commits, PR text, or chat summaries unless the human
-  explicitly asks for that.
-- Do not commit `.env` or move secret values into tracked files.
-- If you only need to mention credential availability, refer to the variable names, not the values.
+- Chinese docs are the source of truth for this site; English pages are maintained mirrors and must be updated in the same change
+- The canonical local commands are `npm run lint`, `npm run build`, and `npm run typecheck`
+- Use Playwright or equivalent product verification only when text inspection of `../tiangong-lca-next` is not enough to confirm the current UI flow or screenshot target
+- If a page is only partially fixed, update `TODO.docs-system-gaps.md` in the same working session
 
-## Playwright And Screenshot Workflow
+## Hard Boundaries
 
-Use Playwright when product verification needs more than static code inspection, especially when:
+- Do not document product behavior here without checking `../tiangong-lca-next`
+- Do not update a Chinese page without updating the paired English mirror in the same change
+- Do not leave durable drift notes only in chat when `TODO.docs-system-gaps.md` should be updated
+- Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
 
-- a docs page depends on exact UI wording or control placement
-- the current screenshots look stale or mismatched
-- a hidden or role-based workflow needs confirmation in the live system
-- a new how-to page would be materially clearer with a real product screenshot
+## Workspace Integration
 
-When Playwright is used:
+A merged PR in `tiangong-lca-next-docs` is repo-complete, not delivery-complete.
 
-1. Prefer logging into `https://lca.tiangong.earth/` with the `.env` credentials only when the
-   workflow actually requires authentication.
-2. Verify the target flow before editing docs.
-3. Capture screenshots that match the style of existing docs assets in this repo.
-4. Unless the screenshot is specifically meant to compare locales or explain a Chinese-only text
-   difference, use the **English product UI** for screenshots even when the surrounding docs page is
-   Chinese.
-5. Match the repository's existing screenshot sharpness. For local or cropped screenshots, do **not**
-   force a full `1920x1080` composition when it is unnecessary; instead, keep the crop focused but
-   capture it at higher pixel density, typically with `deviceScaleFactor >= 2`, and preserve
-   high-density PNG metadata consistent with existing assets (the current repo commonly uses
-   ~144 DPI metadata).
-6. If the screenshot is instructional, add red boxes or clear callouts around the relevant control
-   or region before using it in docs.
-7. Save the asset under the nearest matching docs image directory, for example
-   `docs/user-guide/img/` or `docs/MCP/img/`.
-8. Add surrounding explanatory text in the doc so the screenshot supports, rather than replaces, the
-   written instructions.
+If the docs change must ship through the workspace:
 
-Annotation rules for instructional screenshots:
-
-- Prefer simple numbered callouts over embedding full text labels inside the image.
-- Explain those numbers in the surrounding Markdown text, not by drawing long Chinese or English
-  phrases onto the screenshot itself.
-- Keep the marked UI legible. Do not let labels, badges, or thick boxes cover the actual icon,
-  field, or button being explained.
-- When possible, place number badges outside the target region. Use leader lines or extra whitespace
-  rather than stacking the label directly on top of the UI.
-- If a control cluster is too dense, widen the crop, upscale the image, or split one screenshot into
-  multiple focused screenshots instead of forcing overlapping annotations.
-- If text must appear inside the image, keep it short, use a clean sans-serif style, and make sure
-  it is visually secondary to the real UI.
-- For local screenshots, sharpness matters more than canvas size. A smaller crop is acceptable if
-  the resulting PNG still has crisp UI text and high enough sampling density.
-
-Screenshot decision rule:
-
-- This site is primarily written for human readers, so screenshots should be added when they
-  materially improve comprehension of entry points, control placement, or multi-step UI flows.
-- Do not force screenshots onto every page. Prefer a smaller number of high-value screenshots over
-  repetitive image-heavy pages.
-- If a page is already clear from text plus stable UI labels, text-only documentation is acceptable.
-
-Screenshot hygiene:
-
-- Avoid exposing passwords, API keys, raw tokens, or unrelated personal information.
-- Keep the viewport focused on the target workflow, not the entire desktop.
-- If a screenshot includes user-identifying or irrelevant noise, crop or replace it before use.
-
-## Source Of Truth Rules
-
-- For shipped product behavior, treat `../tiangong-lca-next` as the source of truth.
-- For Chinese public docs, treat `docs/**` as the source of truth unless an explicit exception is
-  documented.
-- For English public docs, treat `i18n/en/docusaurus-plugin-content-docs/current/**` as the mirror
-  that must stay aligned with the Chinese source.
-- For internal maintenance records, use repo-root files such as `AGENTS.md` and
-  `TODO.docs-system-gaps.md`. Do not put internal-only notes under `docs/**` unless they are meant
-  to be published on the public site.
-
-## Documentation Workflow
-
-When making public documentation changes:
-
-1. Inspect the relevant product behavior in `../tiangong-lca-next` first.
-2. Update the Chinese page in `docs/**`.
-3. Update the English mirror in `i18n/en/docusaurus-plugin-content-docs/current/**` in the same
-   change.
-4. Update `sidebars.ts`, `docs/intro.md`, `docs/user-guide/overview.md`, or `docs/changelog/*` if
-   the information architecture or discovery path changed.
-5. If the change closes only part of a known gap, update `TODO.docs-system-gaps.md` in the same
-   session.
-
-When adding a new public page:
-
-1. Add the Chinese source page under `docs/**`.
-2. Add the English mirror under `i18n/en/docusaurus-plugin-content-docs/current/**`.
-3. Register the page in `sidebars.ts` if it should be discoverable in site navigation.
-4. Ensure cross-links use site-relative doc links, not raw repository paths.
-
-## Drift Hotspots To Check
-
-These product areas are especially likely to drift from the docs site:
-
-- `../tiangong-lca-next/config/routes.ts`
-- `../tiangong-lca-next/src/app.tsx`
-- `../tiangong-lca-next/src/components/RightContent/index.tsx`
-- `../tiangong-lca-next/src/components/ImportTidasPackage/index.tsx`
-- `../tiangong-lca-next/src/components/ExportTidasPackage/index.tsx`
-- `../tiangong-lca-next/src/components/LcaTaskCenter/index.tsx`
-- `../tiangong-lca-next/src/pages/Account/index.tsx`
-- `../tiangong-lca-next/src/pages/Review/index.tsx`
-- `../tiangong-lca-next/src/pages/ManageSystem/index.tsx`
-- `../tiangong-lca-next/src/pages/Processes/Analysis/index.tsx`
-
-Check these areas whenever the docs touch:
-
-- account and authentication
-- API keys
-- data import/export
-- task center behavior
-- review workflow
-- admin/system management
-- advanced LCIA or analysis workflows
-- top-bar controls and navigation
-
-## Writing Rules
-
-- Prefer updating an existing page over creating a near-duplicate page.
-- Keep user-facing docs task-oriented and product-accurate.
-- Distinguish public user docs from maintainer/internal guidance.
-- Use concrete product labels that match the UI.
-- If screenshots are outdated but text is being updated anyway, note the screenshot gap in
-  `TODO.docs-system-gaps.md`.
-- If a Chinese page is renamed, moved, or removed, update the English mirror and sidebar references
-  in the same change.
-- If you find an English-only orphan page, either restore the Chinese source, merge it, or record
-  the exception in `TODO.docs-system-gaps.md`.
-
-## Validation Expectations
-
-- Run `npm run lint` after changing Markdown files.
-- Run `npm run build` when changing site structure, navigation, MDX, config, or localization paths.
-- Run `npm run typecheck` when editing TypeScript config files such as `docusaurus.config.ts` or
-  `sidebars.ts`.
-
-## Change Discipline
-
-- Keep diffs scoped to the documentation problem being solved.
-- Do not silently rewrite large sections of unrelated content.
-- If you change the documentation workflow or maintenance contract for this repo, update this file
-  first.
+1. merge the child PR into `tiangong-lca-next-docs`
+2. update the `lca-workspace` submodule pointer deliberately
+3. complete any later workspace-level validation that depends on the updated docs snapshot

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -112,6 +112,40 @@
         }
       ],
       "reason": "Navigation, site config, and runtime wiring change how future docs work should be routed and checked."
+    },
+    {
+      "id": "next-docs-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "next-docs",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,117 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "5c945a72f0847e9c27f56a38eb9aca7389f69fa9",
+  "rules": [
+    {
+      "id": "next-docs-bootstrap-contract",
+      "scope": "repo",
+      "repo": "next-docs",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "TODO.docs-system-gaps.md",
+          "kind": "doc-backlog"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and review-trigger rules must stay aligned."
+    },
+    {
+      "id": "next-docs-public-content-contract",
+      "scope": "repo",
+      "repo": "next-docs",
+      "triggers": [
+        {
+          "path": "docs/**",
+          "kind": "public-doc-source"
+        },
+        {
+          "path": "i18n/en/docusaurus-plugin-content-docs/current/**",
+          "kind": "public-doc-mirror"
+        },
+        {
+          "path": "static/**",
+          "kind": "public-asset"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Public pages, mirrors, and assets define what this repo publishes and should refresh the repo contract when they change."
+    },
+    {
+      "id": "next-docs-site-structure-contract",
+      "scope": "repo",
+      "repo": "next-docs",
+      "triggers": [
+        {
+          "path": "sidebars.ts",
+          "kind": "site-nav"
+        },
+        {
+          "path": "docusaurus.config.ts",
+          "kind": "site-config"
+        },
+        {
+          "path": "src/**",
+          "kind": "site-runtime"
+        },
+        {
+          "path": "package.json",
+          "kind": "site-runtime-config"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Navigation, site config, and runtime wiring change how future docs work should be routed and checked."
+    }
+  ]
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -101,7 +101,7 @@
       "notes": [
         "Run npm run typecheck when changing Docusaurus TypeScript config such as sidebars.ts or docusaurus.config.ts.",
         "If product behavior is ambiguous, verify against ../tiangong-lca-next before changing public docs.",
-        "AI-doc changes should still run the root warning-only ai-doc-lint."
+        "AI-doc changes should still run the repo-local ai-doc-lint workflow or the equivalent local node command."
       ]
     }
   }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,108 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "5c945a72f0847e9c27f56a38eb9aca7389f69fa9",
+  "repo": {
+    "id": "next-docs",
+    "path": "tiangong-lca-next-docs",
+    "canonicalRepo": "linancn/tiangong-lca-next-docs",
+    "purpose": "Public Docusaurus documentation site for TianGong LCA.",
+    "entryDoc": "AGENTS.md",
+    "docImpactDoc": "ai/doc-impact.yaml",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "main",
+    "routinePrBase": "main",
+    "branchModel": "M1",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main may bump merged main-branch docs snapshots when the workspace intends to ship the updated docs site state.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/linancn/tiangong-lca-next-docs/issues/33"
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "docs/**",
+          "role": "canonical Chinese public-doc source"
+        },
+        {
+          "path": "i18n/en/docusaurus-plugin-content-docs/current/**",
+          "role": "maintained English mirror of the public docs"
+        },
+        {
+          "path": "sidebars.ts",
+          "role": "public navigation structure"
+        },
+        {
+          "path": "docusaurus.config.ts",
+          "role": "site config, locales, navbar, footer, and plugin wiring"
+        },
+        {
+          "path": "src/**",
+          "role": "docs-site components and custom site behavior"
+        },
+        {
+          "path": "static/**",
+          "role": "published docs assets including screenshots and images"
+        },
+        {
+          "path": "TODO.docs-system-gaps.md",
+          "role": "durable maintenance backlog for product/docs drift"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "tiangong-lca-next",
+          "doesNotOwn": [
+            "shipped product behavior",
+            "route truth",
+            "UI control semantics"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "root integration state",
+            "submodule pointer updates"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "public page content and bilingual mirror sync",
+        "paths": [
+          "docs/**",
+          "i18n/en/docusaurus-plugin-content-docs/current/**"
+        ]
+      },
+      {
+        "topic": "site navigation and docs discovery",
+        "paths": [
+          "sidebars.ts",
+          "docusaurus.config.ts",
+          "src/**"
+        ]
+      },
+      {
+        "topic": "product/docs drift tracking and screenshots",
+        "paths": [
+          "TODO.docs-system-gaps.md",
+          "static/**"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "npm run lint",
+        "npm run build"
+      ],
+      "notes": [
+        "Run npm run typecheck when changing Docusaurus TypeScript config such as sidebars.ts or docusaurus.config.ts.",
+        "If product behavior is ambiguous, verify against ../tiangong-lca-next before changing public docs.",
+        "AI-doc changes should still run the root warning-only ai-doc-lint."
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes linancn/tiangong-lca-next-docs#33

## Summary
- Add a checked-in AI contract layer with AGENTS.md, ai/repo.yaml, and ai/doc-impact.yaml.
- Keep public-doc ownership distinct from shipped frontend behavior in the repo AI layer.

## Validation
- npm run lint
- npm run build

## Workspace Integration
- If the merged doc change needs to ship in the workspace snapshot, bump the submodule in lca-workspace after merge.