### PR TITLE
feat: add docs publish llms pipeline

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -25,6 +25,7 @@ ownership:
           - .docpact/config.yaml
           - docs/agents/**
           - .github/workflows/ai-doc-lint.yml
+          - .github/workflows/publish-docs.yml
       ownerRepo: next-docs
     - id: public-doc-content
       paths:
@@ -41,6 +42,10 @@ ownership:
           - src/**
           - package.json
           - tsconfig.json
+          - context7.json
+          - scripts/generate-llms-txt.mjs
+          - scripts/check-publication-scope.mjs
+          - scripts/publication-policy.mjs
       ownerRepo: next-docs
 
     - id: local-docpact-push-gate
@@ -64,12 +69,17 @@ coverage:
     - docs/**
     - i18n/en/docusaurus-plugin-content-docs/current/**
     - static/**
+    - context7.json
+    - scripts/generate-llms-txt.mjs
+    - scripts/check-publication-scope.mjs
+    - scripts/publication-policy.mjs
     - sidebars.ts
     - docusaurus.config.ts
     - src/**
     - package.json
     - tsconfig.json
     - .github/workflows/ai-doc-lint.yml
+    - .github/workflows/publish-docs.yml
   exclude:
     - .git/**
     - .github/scripts/**
@@ -102,6 +112,11 @@ routing:
         - src/**
         - package.json
         - tsconfig.json
+        - context7.json
+        - scripts/generate-llms-txt.mjs
+        - scripts/check-publication-scope.mjs
+        - scripts/publication-policy.mjs
+        - .github/workflows/publish-docs.yml
     drift-backlog:
       paths:
         - TODO.docs-system-gaps.md
@@ -233,6 +248,8 @@ rules:
     triggers:
       - path: .github/workflows/ai-doc-lint.yml
         kind: automation
+      - path: .github/workflows/publish-docs.yml
+        kind: automation
     requiredDocs:
       - path: AGENTS.md
         mode: review_or_update
@@ -241,6 +258,36 @@ rules:
       - path: docs/agents/repo-validation.md
         mode: review_or_update
     reason: Documentation governance automation changes alter the maintenance gate and proof expectations.
+  - id: next-docs-publication-pipeline
+    scope: repo
+    repo: next-docs
+    triggers:
+      - path: .github/workflows/publish-docs.yml
+        kind: publication-automation
+      - path: context7.json
+        kind: ai-publication-config
+      - path: static/llms.txt
+        kind: ai-publication-index
+      - path: scripts/generate-llms-txt.mjs
+        kind: publication-automation
+      - path: scripts/check-publication-scope.mjs
+        kind: publication-automation
+      - path: scripts/publication-policy.mjs
+        kind: publication-automation
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: README.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+      - path: docs/dev/dev-env.md
+        mode: review_or_update
+      - path: i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+        mode: review_or_update
+    reason: The publish workflow, llms.txt generator, publication scope policy, and Context7 source config define what public docs are exposed after main merges.
   - id: next-docs-local-docpact-push-gate
     scope: repo
     repo: next-docs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,272 @@
+name: Publish docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: publish-docs-main
+  cancel-in-progress: false
+
+env:
+  DOCS_SITE_URL: https://docs.tiangong.earth
+  CLOUDFLARE_PROJECT_NAME: tiangong-lca-next-docs
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate llms.txt
+        run: npm run docs:llms
+
+      - name: Check llms.txt
+        run: npm run docs:llms:check
+
+      - name: Check publication scope before build
+        run: npm run docs:publication-scope:check
+
+      - name: Lint markdown
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build Docusaurus site
+        run: npm run build
+
+      - name: Check publication scope after build
+        run: npm run docs:publication-scope:check
+
+      - name: Resolve publish context
+        id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CONTEXT7_LIBRARY_NAME: ${{ vars.CONTEXT7_LIBRARY_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${CLOUDFLARE_API_TOKEN}" ] && [ -n "${CLOUDFLARE_ACCOUNT_ID}" ]; then
+            echo "cloudflare_ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cloudflare_ready=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "${CONTEXT7_API_KEY}" ]; then
+            echo "context7_ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "context7_ready=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "${CONTEXT7_LIBRARY_NAME}" ]; then
+            library_name="${CONTEXT7_LIBRARY_NAME}"
+          else
+            library_name="/${GITHUB_REPOSITORY}"
+          fi
+          echo "context7_library_name=${library_name}" >> "$GITHUB_OUTPUT"
+
+          pulls_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            -H "Accept: application/vnd.github+json" 2>/dev/null || printf '[]')"
+          pull_urls="$(printf '%s' "$pulls_json" | jq -r '.[].html_url' | paste -sd ', ' -)"
+          echo "pull_urls=${pull_urls}" >> "$GITHUB_OUTPUT"
+
+      - name: Report missing Cloudflare secrets
+        if: steps.context.outputs.cloudflare_ready != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          title="Docs publish blocked: Cloudflare secrets missing"
+          body="$(mktemp)"
+          cat > "$body" <<EOF
+          The docs publish workflow could not deploy commit ${GITHUB_SHA} because one or more Cloudflare secrets are missing.
+
+          Required repository secrets:
+          - CLOUDFLARE_API_TOKEN
+          - CLOUDFLARE_ACCOUNT_ID
+
+          Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
+
+          existing="$(gh issue list --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "$body"
+          else
+            gh issue create --title "$title" --body-file "$body"
+          fi
+
+          {
+            echo "## Docs publish blocked"
+            echo
+            echo "Cloudflare secrets are missing; deployment did not run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit 1
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npm install -g wrangler
+          wrangler pages deploy build --project-name "${CLOUDFLARE_PROJECT_NAME}" --branch main
+
+      - name: Verify published llms.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          llms_url="${DOCS_SITE_URL%/}/llms.txt"
+          for attempt in $(seq 1 12); do
+            if curl -fsSL "$llms_url" -o /tmp/published-llms.txt && grep -q "$GITHUB_SHA" /tmp/published-llms.txt; then
+              echo "Verified $llms_url for commit $GITHUB_SHA"
+              exit 0
+            fi
+
+            echo "Waiting for $llms_url to include $GITHUB_SHA (attempt ${attempt}/12)."
+            sleep 10
+          done
+
+          title="Docs publish blocked: published llms.txt did not match commit"
+          body="$(mktemp)"
+          cat > "$body" <<EOF
+          The docs publish workflow deployed commit ${GITHUB_SHA}, but ${llms_url} did not expose that commit after the retry window.
+
+          Site: ${DOCS_SITE_URL}
+          llms.txt: ${llms_url}
+          Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
+
+          existing="$(gh issue list --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "$body"
+          else
+            gh issue create --title "$title" --body-file "$body"
+          fi
+
+          echo "Published llms.txt did not include $GITHUB_SHA after waiting." >&2
+          exit 1
+
+      - name: Trigger Context7 refresh
+        id: context7
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+          CONTEXT7_LIBRARY_NAME: ${{ steps.context.outputs.context7_library_name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CONTEXT7_API_KEY}" ]; then
+            echo "status=pending_missing_secret" >> "$GITHUB_OUTPUT"
+            echo "Context7 refresh is pending because CONTEXT7_API_KEY is not configured."
+            exit 0
+          fi
+
+          node -e "console.log(JSON.stringify({libraryName: process.env.CONTEXT7_LIBRARY_NAME, branch: 'main'}))" > /tmp/context7-refresh.json
+
+          status_code="$(curl -sS -o /tmp/context7-response.json -w '%{http_code}' \
+            -X POST 'https://context7.com/api/v1/refresh' \
+            -H "Authorization: Bearer ${CONTEXT7_API_KEY}" \
+            -H 'Content-Type: application/json' \
+            --data @/tmp/context7-refresh.json)"
+
+          if [ "$status_code" -ge 200 ] && [ "$status_code" -lt 300 ]; then
+            echo "status=complete" >> "$GITHUB_OUTPUT"
+            echo "Context7 refresh accepted for ${CONTEXT7_LIBRARY_NAME}."
+            cat /tmp/context7-response.json
+            exit 0
+          fi
+
+          echo "status=blocked" >> "$GITHUB_OUTPUT"
+          title="Context7 refresh blocked"
+          body="$(mktemp)"
+          cat > "$body" <<EOF
+          Docs were published for commit ${GITHUB_SHA}, but Context7 refresh failed.
+
+          Library: ${CONTEXT7_LIBRARY_NAME}
+          HTTP status: ${status_code}
+          Site: ${DOCS_SITE_URL}
+          llms.txt: ${DOCS_SITE_URL}/llms.txt
+          Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          Response:
+
+          \`\`\`json
+          $(cat /tmp/context7-response.json)
+          \`\`\`
+          EOF
+
+          existing="$(gh issue list --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "$body"
+          else
+            gh issue create --title "$title" --body-file "$body"
+          fi
+
+          echo "Context7 refresh failed with HTTP ${status_code}." >&2
+          cat /tmp/context7-response.json >&2
+          exit 1
+
+      - name: Record Context7 pending follow-up
+        if: steps.context7.outputs.status == 'pending_missing_secret'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          title="Context7 refresh pending: API secret missing"
+          body="$(mktemp)"
+          cat > "$body" <<EOF
+          Docs were published for commit ${GITHUB_SHA}, but Context7 refresh is pending because CONTEXT7_API_KEY is not configured.
+
+          Library: ${{ steps.context.outputs.context7_library_name }}
+          Site: ${DOCS_SITE_URL}
+          llms.txt: ${DOCS_SITE_URL}/llms.txt
+          Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
+
+          existing="$(gh issue list --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "$body"
+          else
+            gh issue create --title "$title" --body-file "$body"
+          fi
+
+      - name: Write publish summary
+        if: always()
+        run: |
+          {
+            echo "## Docs publish"
+            echo
+            echo "- Commit: ${GITHUB_SHA}"
+            echo "- Site: ${DOCS_SITE_URL}"
+            echo "- llms.txt: ${DOCS_SITE_URL%/}/llms.txt"
+            echo "- Context7 library: ${{ steps.context.outputs.context7_library_name }}"
+            echo "- Context7 status: ${{ steps.context7.outputs.status || 'not-run' }}"
+            echo "- Source PRs: ${{ steps.context.outputs.pull_urls || 'not found' }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,6 +1,7 @@
 name: Publish docs
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -19,7 +20,49 @@ env:
   CLOUDFLARE_PROJECT_NAME: tiangong-lca-next-docs
 
 jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate llms.txt
+        run: npm run docs:llms
+
+      - name: Check llms.txt
+        run: npm run docs:llms:check
+
+      - name: Check publication scope before build
+        run: npm run docs:publication-scope:check
+
+      - name: Lint markdown
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build Docusaurus site
+        run: npm run build
+
+      - name: Check publication scope after build
+        run: npm run docs:publication-scope:check
+
   publish:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -87,15 +87,80 @@ jobs:
           fi
           echo "context7_library_name=${library_name}" >> "$GITHUB_OUTPUT"
 
-          pulls_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
-            -H "Accept: application/vnd.github+json" 2>/dev/null || printf '[]')"
-          pull_urls="$(printf '%s' "$pulls_json" | jq -r '.[].html_url' | paste -sd ', ' -)"
+          pulls_file="$RUNNER_TEMP/commit-pulls.json"
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            -H "Accept: application/vnd.github+json" > "$pulls_file" 2>/dev/null || printf '[]' > "$pulls_file"
+          pull_urls="$(jq -r '.[].html_url' "$pulls_file" | paste -sd ', ' -)"
           echo "pull_urls=${pull_urls}" >> "$GITHUB_OUTPUT"
+
+          node - "$pulls_file" <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('fs');
+
+          const pulls = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const markers = [
+            'docs-impact-local-apply-mapped:v1',
+            'docs-impact-local-replay-mapped:v1',
+          ];
+
+          function escapeRegExp(value) {
+            return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          }
+
+          function hiddenJson(marker, body) {
+            const pattern = new RegExp(`<!--\\s*${escapeRegExp(marker)}\\s*(\\{[\\s\\S]*?\\})\\s*-->`);
+            const match = String(body || '').match(pattern);
+            return match ? JSON.parse(match[1]) : null;
+          }
+
+          let markerName = '';
+          let metadata = null;
+
+          for (const pull of pulls) {
+            for (const marker of markers) {
+              const parsed = hiddenJson(marker, pull.body);
+              if (parsed?.docsImpactIssue) {
+                markerName = marker;
+                metadata = parsed;
+                break;
+              }
+            }
+
+            if (metadata) break;
+          }
+
+          const issueRef = metadata?.docsImpactIssue || '';
+          const match = issueRef.match(/^([^#]+\/[^#]+)#(\d+)$/);
+
+          console.log(`docs_impact_marker=${markerName}`);
+          console.log(`docs_impact_issue=${issueRef}`);
+          console.log(`docs_impact_issue_repo=${match ? match[1] : ''}`);
+          console.log(`docs_impact_issue_number=${match ? match[2] : ''}`);
+          NODE
+
+      - name: Mark docs publish pending
+        if: steps.context.outputs.docs_impact_issue_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_IMPACT_ROOT_TOKEN || github.token }}
+          DOCS_IMPACT_ISSUE_REPO: ${{ steps.context.outputs.docs_impact_issue_repo }}
+          DOCS_IMPACT_ISSUE_NUMBER: ${{ steps.context.outputs.docs_impact_issue_number }}
+        run: |
+          set -euo pipefail
+
+          gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+            --repo "$DOCS_IMPACT_ISSUE_REPO" \
+            --add-label docs-publish-pending || \
+            echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} docs-publish-pending."
+          gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+            --repo "$DOCS_IMPACT_ISSUE_REPO" \
+            --remove-label docs-publish-complete,docs-publish-blocked,context7-refresh-complete || true
 
       - name: Report missing Cloudflare secrets
         if: steps.context.outputs.cloudflare_ready != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          DOCS_IMPACT_ROOT_TOKEN: ${{ secrets.DOCS_IMPACT_ROOT_TOKEN }}
+          DOCS_IMPACT_ISSUE_REPO: ${{ steps.context.outputs.docs_impact_issue_repo }}
+          DOCS_IMPACT_ISSUE_NUMBER: ${{ steps.context.outputs.docs_impact_issue_number }}
         run: |
           set -euo pipefail
 
@@ -124,6 +189,29 @@ jobs:
             echo "Cloudflare secrets are missing; deployment did not run."
           } >> "$GITHUB_STEP_SUMMARY"
 
+          if [ -n "${DOCS_IMPACT_ISSUE_NUMBER}" ]; then
+            root_body="$(mktemp)"
+            cat > "$root_body" <<EOF
+          Docs publish is blocked for commit ${GITHUB_SHA}: Cloudflare secrets are missing.
+
+          Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue comment "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --body-file "$root_body" || \
+              echo "::warning::Could not comment on ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER}."
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --add-label docs-publish-blocked || \
+              echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} docs-publish-blocked."
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --remove-label docs-publish-pending || true
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --remove-label docs-publish-complete || true
+          fi
+
           exit 1
 
       - name: Deploy to Cloudflare Pages
@@ -138,6 +226,9 @@ jobs:
       - name: Verify published llms.txt
         env:
           GH_TOKEN: ${{ github.token }}
+          DOCS_IMPACT_ROOT_TOKEN: ${{ secrets.DOCS_IMPACT_ROOT_TOKEN }}
+          DOCS_IMPACT_ISSUE_REPO: ${{ steps.context.outputs.docs_impact_issue_repo }}
+          DOCS_IMPACT_ISSUE_NUMBER: ${{ steps.context.outputs.docs_impact_issue_number }}
         run: |
           set -euo pipefail
 
@@ -170,7 +261,53 @@ jobs:
           fi
 
           echo "Published llms.txt did not include $GITHUB_SHA after waiting." >&2
+
+          if [ -n "${DOCS_IMPACT_ISSUE_NUMBER}" ]; then
+            root_body="$(mktemp)"
+            cat > "$root_body" <<EOF
+          Docs publish is blocked for commit ${GITHUB_SHA}: published llms.txt did not expose the deployed commit after the retry window.
+
+          Site: ${DOCS_SITE_URL}
+          llms.txt: ${llms_url}
+          Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue comment "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --body-file "$root_body" || \
+              echo "::warning::Could not comment on ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER}."
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --add-label docs-publish-blocked || \
+              echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} docs-publish-blocked."
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --remove-label docs-publish-pending || true
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --remove-label docs-publish-complete || true
+          fi
+
           exit 1
+
+      - name: Mark docs publish complete
+        if: steps.context.outputs.docs_impact_issue_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_IMPACT_ROOT_TOKEN || github.token }}
+          DOCS_IMPACT_ISSUE_REPO: ${{ steps.context.outputs.docs_impact_issue_repo }}
+          DOCS_IMPACT_ISSUE_NUMBER: ${{ steps.context.outputs.docs_impact_issue_number }}
+        run: |
+          set -euo pipefail
+
+          gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+            --repo "$DOCS_IMPACT_ISSUE_REPO" \
+            --add-label docs-publish-complete || \
+            echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} docs-publish-complete."
+          gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+            --repo "$DOCS_IMPACT_ISSUE_REPO" \
+            --remove-label docs-publish-pending || true
+          gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+            --repo "$DOCS_IMPACT_ISSUE_REPO" \
+            --remove-label docs-publish-blocked || true
 
       - name: Trigger Context7 refresh
         id: context7
@@ -178,6 +315,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
           CONTEXT7_LIBRARY_NAME: ${{ steps.context.outputs.context7_library_name }}
+          DOCS_IMPACT_ROOT_TOKEN: ${{ secrets.DOCS_IMPACT_ROOT_TOKEN }}
+          DOCS_IMPACT_ISSUE_REPO: ${{ steps.context.outputs.docs_impact_issue_repo }}
+          DOCS_IMPACT_ISSUE_NUMBER: ${{ steps.context.outputs.docs_impact_issue_number }}
         run: |
           set -euo pipefail
 
@@ -230,12 +370,60 @@ jobs:
 
           echo "Context7 refresh failed with HTTP ${status_code}." >&2
           cat /tmp/context7-response.json >&2
+
+          if [ -n "${DOCS_IMPACT_ISSUE_NUMBER}" ]; then
+            root_body="$(mktemp)"
+            cat > "$root_body" <<EOF
+          Docs were published for commit ${GITHUB_SHA}, but Context7 refresh is blocked.
+
+          Library: ${CONTEXT7_LIBRARY_NAME}
+          HTTP status: ${status_code}
+          Site: ${DOCS_SITE_URL}
+          llms.txt: ${DOCS_SITE_URL}/llms.txt
+          Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue comment "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --body-file "$root_body" || \
+              echo "::warning::Could not comment on ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER}."
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --add-label docs-publish-blocked,context7-refresh-pending || \
+              echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} Context7 blocked."
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --remove-label context7-refresh-complete || true
+          fi
+
           exit 1
+
+      - name: Mark Context7 refresh complete
+        if: steps.context7.outputs.status == 'complete' && steps.context.outputs.docs_impact_issue_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_IMPACT_ROOT_TOKEN || github.token }}
+          DOCS_IMPACT_ISSUE_REPO: ${{ steps.context.outputs.docs_impact_issue_repo }}
+          DOCS_IMPACT_ISSUE_NUMBER: ${{ steps.context.outputs.docs_impact_issue_number }}
+        run: |
+          set -euo pipefail
+
+          gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+            --repo "$DOCS_IMPACT_ISSUE_REPO" \
+            --add-label context7-refresh-complete || \
+            echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} context7-refresh-complete."
+          gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+            --repo "$DOCS_IMPACT_ISSUE_REPO" \
+            --remove-label context7-refresh-pending || true
+          gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+            --repo "$DOCS_IMPACT_ISSUE_REPO" \
+            --remove-label docs-publish-blocked || true
 
       - name: Record Context7 pending follow-up
         if: steps.context7.outputs.status == 'pending_missing_secret'
         env:
           GH_TOKEN: ${{ github.token }}
+          DOCS_IMPACT_ROOT_TOKEN: ${{ secrets.DOCS_IMPACT_ROOT_TOKEN }}
+          DOCS_IMPACT_ISSUE_REPO: ${{ steps.context.outputs.docs_impact_issue_repo }}
+          DOCS_IMPACT_ISSUE_NUMBER: ${{ steps.context.outputs.docs_impact_issue_number }}
         run: |
           set -euo pipefail
 
@@ -257,6 +445,29 @@ jobs:
             gh issue create --title "$title" --body-file "$body"
           fi
 
+          if [ -n "${DOCS_IMPACT_ISSUE_NUMBER}" ]; then
+            root_body="$(mktemp)"
+            cat > "$root_body" <<EOF
+          Docs were published for commit ${GITHUB_SHA}, but Context7 refresh is pending because CONTEXT7_API_KEY is not configured.
+
+          Library: ${{ steps.context.outputs.context7_library_name }}
+          Site: ${DOCS_SITE_URL}
+          llms.txt: ${DOCS_SITE_URL}/llms.txt
+          Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue comment "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --body-file "$root_body" || \
+              echo "::warning::Could not comment on ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER}."
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --add-label context7-refresh-pending || \
+              echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} context7-refresh-pending."
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --remove-label context7-refresh-complete || true
+          fi
+
       - name: Write publish summary
         if: always()
         run: |
@@ -269,4 +480,5 @@ jobs:
             echo "- Context7 library: ${{ steps.context.outputs.context7_library_name }}"
             echo "- Context7 status: ${{ steps.context7.outputs.status || 'not-run' }}"
             echo "- Source PRs: ${{ steps.context.outputs.pull_urls || 'not found' }}"
+            echo "- Docs impact issue: ${{ steps.context.outputs.docs_impact_issue || 'not found' }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -195,7 +195,7 @@ jobs:
             echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} docs-publish-pending."
           gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
             --repo "$DOCS_IMPACT_ISSUE_REPO" \
-            --remove-label docs-publish-complete,docs-publish-blocked,context7-refresh-complete || true
+            --remove-label docs-publish-complete,docs-publish-blocked,context7-refresh-pending,context7-refresh-complete,context7-refresh-blocked || true
 
       - name: Report missing Cloudflare secrets
         if: steps.context.outputs.cloudflare_ready != 'true'
@@ -364,6 +364,16 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ -n "${DOCS_IMPACT_ISSUE_NUMBER}" ]; then
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --add-label context7-refresh-pending || \
+              echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} context7-refresh-pending."
+            GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
+              --repo "$DOCS_IMPACT_ISSUE_REPO" \
+              --remove-label context7-refresh-complete,context7-refresh-blocked || true
+          fi
+
           if [ -z "${CONTEXT7_API_KEY}" ]; then
             echo "status=pending_missing_secret" >> "$GITHUB_OUTPUT"
             echo "Context7 refresh is pending because CONTEXT7_API_KEY is not configured."
@@ -431,11 +441,11 @@ jobs:
               echo "::warning::Could not comment on ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER}."
             GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
               --repo "$DOCS_IMPACT_ISSUE_REPO" \
-              --add-label docs-publish-blocked,context7-refresh-pending || \
+              --add-label context7-refresh-blocked || \
               echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} Context7 blocked."
             GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
               --repo "$DOCS_IMPACT_ISSUE_REPO" \
-              --remove-label context7-refresh-complete || true
+              --remove-label context7-refresh-pending,context7-refresh-complete || true
           fi
 
           exit 1
@@ -458,7 +468,7 @@ jobs:
             --remove-label context7-refresh-pending || true
           gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
             --repo "$DOCS_IMPACT_ISSUE_REPO" \
-            --remove-label docs-publish-blocked || true
+            --remove-label context7-refresh-blocked || true
 
       - name: Record Context7 pending follow-up
         if: steps.context7.outputs.status == 'pending_missing_secret'
@@ -508,7 +518,7 @@ jobs:
               echo "::warning::Could not mark ${DOCS_IMPACT_ISSUE_REPO}#${DOCS_IMPACT_ISSUE_NUMBER} context7-refresh-pending."
             GH_TOKEN="${DOCS_IMPACT_ROOT_TOKEN:-$GH_TOKEN}" gh issue edit "$DOCS_IMPACT_ISSUE_NUMBER" \
               --repo "$DOCS_IMPACT_ISSUE_REPO" \
-              --remove-label context7-refresh-complete || true
+              --remove-label context7-refresh-complete,context7-refresh-blocked || true
           fi
 
       - name: Write publish summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,11 @@ checkPaths:
   - docusaurus.config.ts
   - src/**
   - static/**
+  - context7.json
+  - .github/workflows/publish-docs.yml
+  - scripts/generate-llms-txt.mjs
+  - scripts/check-publication-scope.mjs
+  - scripts/publication-policy.mjs
   - package.json
   - .githooks/**
   - scripts/docpact-gate.sh
@@ -82,7 +87,8 @@ Route those tasks to:
 
 - Repo-local documentation governance is enforced through `.docpact/config.yaml` and `.github/workflows/ai-doc-lint.yml`.
 - Chinese docs are the source of truth for this site; English pages are maintained mirrors and must be updated in the same change
-- The canonical local commands are `npm run lint`, `npm run build`, and `npm run typecheck`
+- The canonical local commands are `npm run lint`, `npm run build`, `npm run typecheck`, `npm run docs:llms:check`, and `npm run docs:publication-scope:check`
+- `static/llms.txt`, `context7.json`, and `.github/workflows/publish-docs.yml` define the public AI-consumption and post-merge publication boundary
 - Use Playwright or equivalent product verification only when text inspection of `../tiangong-lca-next` is not enough to confirm the current UI flow or screenshot target
 - If a page is only partially fixed, update `TODO.docs-system-gaps.md` in the same working session
 - For documentation-governance changes, run `docpact validate-config --root . --strict` and `docpact lint --root . --base origin/main --head HEAD --mode enforce`
@@ -93,6 +99,7 @@ Route those tasks to:
 - Do not update a Chinese page without updating the paired English mirror in the same change
 - Do not leave durable drift notes only in chat when `TODO.docs-system-gaps.md` should be updated
 - Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
+- Do not add internal agent docs, TODOs, plans, incidents, or governance runbooks to `static/llms.txt` or the Context7 source scope
 
 ## Workspace Integration
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
-# TianGong LCA Docs
+---
+title: TianGong LCA Docs README
+docType: guide
+scope: repo
+status: active
+authoritative: true
+owner: next-docs
+language: en
+whenToUse:
+  - when setting up or maintaining the public Docusaurus docs repository
+  - when choosing local validation commands for public docs, llms.txt, or publication-scope work
+whenToUpdate:
+  - when docs repo setup, validation, publication, or AI-consumption commands change
+checkPaths:
+  - README.md
+  - package.json
+  - .github/workflows/publish-docs.yml
+  - scripts/generate-llms-txt.mjs
+  - scripts/check-publication-scope.mjs
+  - scripts/publication-policy.mjs
+  - context7.json
+  - static/llms.txt
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20f0a67cd7ec473f1d37fff4df534ea7fcb44349
+related:
+  - AGENTS.md
+  - docs/agents/repo-validation.md
+  - docs/dev/dev-env.md
+---
+
+## TianGong LCA Docs
 
 This repository contains the public Docusaurus site for TianGong LCA.
 
@@ -33,6 +63,9 @@ npm ci
 npm run start
 npm run lint
 npm run lint:fix
+npm run docs:llms
+npm run docs:llms:check
+npm run docs:publication-scope:check
 npm run typecheck
 npm run build
 npm run serve
@@ -44,6 +77,8 @@ For public-doc changes, run at least:
 
 ```bash
 npm run lint
+npm run docs:llms:check
+npm run docs:publication-scope:check
 npm run build
 ```
 
@@ -72,6 +107,12 @@ For the full maintainer workflow, read:
 The default online verification target is `https://lca.tiangong.earth/`.
 
 ## Publish
+
+Every push to `main` runs `.github/workflows/publish-docs.yml`, which regenerates `static/llms.txt`,
+checks the publication scope, builds the Docusaurus site, deploys Cloudflare Pages, verifies
+`/llms.txt`, and refreshes Context7 when `CONTEXT7_API_KEY` is configured.
+
+The legacy tag-triggered release workflow remains available for version-style releases:
 
 ```bash
 git tag

--- a/TODO.docs-system-gaps.md
+++ b/TODO.docs-system-gaps.md
@@ -1,4 +1,34 @@
-# Docs/System Gap TODO
+---
+title: Docs/System Gap TODO
+docType: backlog
+scope: repo
+status: active
+authoritative: false
+owner: next-docs
+language: en
+whenToUse:
+  - when recording durable product/docs drift discovered during docs maintenance
+  - when a docs impact worker finds user-visible product behavior that is not yet covered by public docs
+whenToUpdate:
+  - when public docs drift is found, reprioritized, verified, or closed
+  - when publication checks reveal a user-facing documentation gap that needs follow-up work
+checkPaths:
+  - TODO.docs-system-gaps.md
+  - docs/**
+  - i18n/en/docusaurus-plugin-content-docs/current/**
+  - scripts/generate-llms-txt.mjs
+  - scripts/check-publication-scope.mjs
+  - context7.json
+  - static/llms.txt
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20f0a67cd7ec473f1d37fff4df534ea7fcb44349
+related:
+  - AGENTS.md
+  - README.md
+  - docs/dev/docs-product-sync.md
+---
+
+## Docs/System Gap TODO
 
 This file is a long-term maintenance backlog for gaps between:
 
@@ -17,6 +47,8 @@ of truth once a gap has been identified.
 - Prefer one durable item per gap area instead of scattered notes.
 - Keep internal maintenance notes here at repo root. Do not place them under `docs/**` unless they
   are meant to be published on the site.
+- Publication pipeline changes (`llms.txt`, Context7, or publish workflow) do not replace this
+  backlog; if they reveal stale or missing user-facing documentation, add or update an item here.
 
 ## Verification Notes
 

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "TianGong LCA Docs",
+  "description": "Public TianGong LCA user documentation, integration guides, OpenAPI usage notes, MCP setup, deployment guidance, FAQ, and changelog.",
+  "branch": "main",
+  "folders": [
+    "docs",
+    "i18n/en/docusaurus-plugin-content-docs/current"
+  ],
+  "excludeFolders": [
+    "docs/agents",
+    ".agents",
+    ".docpact",
+    "_docs",
+    ".github",
+    "scripts",
+    "build",
+    ".docusaurus",
+    "node_modules"
+  ],
+  "excludeFiles": [
+    "AGENTS.md",
+    "README.md",
+    "TODO.docs-system-gaps.md",
+    "CHANGELOG.md",
+    "LICENSE.md"
+  ],
+  "rules": [
+    "Use only public Docusaurus docs pages; do not expose internal agent, planning, incident, TODO, or governance execution records.",
+    "Treat zh-CN docs under docs/ as the source of truth and /en pages as maintained English mirrors.",
+    "Prefer stable user-facing pages, OpenAPI guides, MCP guides, deployment docs, FAQ, and changelog entries for answers."
+  ]
+}

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,6 +22,11 @@ checkPaths:
   - docusaurus.config.ts
   - src/**
   - static/**
+  - context7.json
+  - .github/workflows/publish-docs.yml
+  - scripts/generate-llms-txt.mjs
+  - scripts/check-publication-scope.mjs
+  - scripts/publication-policy.mjs
   - TODO.docs-system-gaps.md
   - .githooks/pre-push
   - scripts/docpact-gate.sh
@@ -34,7 +39,7 @@ related:
   - docs/agents/repo-validation.md
 ---
 
-# next-docs Repo Architecture
+## next-docs Repo Architecture
 
 `tiangong-lca-next-docs` owns the public TianGong LCA documentation site built with Docusaurus.
 
@@ -43,6 +48,7 @@ related:
 - `docs/**` is the canonical Chinese public-doc source.
 - `i18n/en/docusaurus-plugin-content-docs/current/**` is the maintained English mirror and should change with its paired Chinese page.
 - `sidebars.ts`, `docusaurus.config.ts`, `src/**`, and `static/**` define site structure, presentation, screenshots, and custom site behavior.
+- `static/llms.txt`, `context7.json`, `.github/workflows/publish-docs.yml`, and `scripts/*llms*` / `scripts/*publication*` define the public AI-consumption and post-merge publication boundary.
 - `TODO.docs-system-gaps.md` is the durable backlog for product/docs drift.
 
 ## Non-Owner Boundaries

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -17,7 +17,12 @@ checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
   - .github/workflows/ai-doc-lint.yml
+  - .github/workflows/publish-docs.yml
   - package.json
+  - context7.json
+  - scripts/generate-llms-txt.mjs
+  - scripts/check-publication-scope.mjs
+  - scripts/publication-policy.mjs
   - sidebars.ts
   - docusaurus.config.ts
   - docs/**
@@ -34,7 +39,7 @@ related:
   - docs/agents/repo-architecture.md
 ---
 
-# next-docs Validation Guide
+## next-docs Validation Guide
 
 The canonical local commands are:
 
@@ -42,6 +47,8 @@ The canonical local commands are:
 npm run lint
 npm run build
 npm run typecheck
+npm run docs:llms:check
+npm run docs:publication-scope:check
 ```
 
 Use the narrowest command set that proves the touched area.
@@ -50,6 +57,8 @@ Use the narrowest command set that proves the touched area.
 
 - Public docs changes require checking the Chinese source and English mirror together.
 - Navigation or site-config changes require at least typecheck and build when feasible.
+- Publication pipeline changes require `npm run docs:llms:check` and `npm run docs:publication-scope:check`; if they affect build output, also run `npm run build` and rerun the publication-scope check afterward.
+- `static/llms.txt` must list only public docs pages, and `context7.json` must keep Context7 scoped to public docs with internal agent, TODO, plan, incident, and governance execution records excluded.
 - Product-behavior documentation changes require checking `../tiangong-lca-next` when behavior is ambiguous.
 - Partial fixes to product/docs drift must update `TODO.docs-system-gaps.md`.
 - Documentation-governance changes require docpact validation.

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -1,5 +1,30 @@
 ---
 sidebar_position: 1
+title: 开发环境配置
+docType: guide
+scope: repo
+status: active
+authoritative: true
+owner: next-docs
+language: zh-CN
+whenToUse:
+  - when setting up local next-docs development or validation commands
+  - when publishing docs, llms.txt, or Context7 source updates
+whenToUpdate:
+  - when package scripts, build commands, publish workflow, or publication-scope checks change
+checkPaths:
+  - package.json
+  - .github/workflows/build.yml
+  - .github/workflows/publish-docs.yml
+  - scripts/generate-llms-txt.mjs
+  - scripts/check-publication-scope.mjs
+  - context7.json
+  - static/llms.txt
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20f0a67cd7ec473f1d37fff4df534ea7fcb44349
+related:
+  - i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+  - docs/agents/repo-validation.md
 ---
 
 # 开发环境配置
@@ -57,6 +82,26 @@ npm run start
 npm run lint
 ```
 
+### 生成和检查 AI 文档索引
+
+```bash
+npm run docs:llms
+npm run docs:llms:check
+```
+
+`docs:llms` 会从公开 Docusaurus 文档生成 `static/llms.txt`。`docs:llms:check`
+用于确认已提交的索引与当前公开文档内容一致。
+
+### 检查公开发布范围
+
+```bash
+npm run docs:publication-scope:check
+```
+
+该命令会检查 `static/llms.txt`、`sidebars.ts`、`context7.json` 以及存在时的
+`build/llms.txt`，防止内部 agent 文档、TODO、计划、事故记录或治理执行材料进入公开 AI
+消费范围。
+
 ### 自动修复可修复的 Markdown 问题
 
 ```bash
@@ -93,6 +138,8 @@ npm run write-translations -- --locale en
 
 ```bash
 npm run lint
+npm run docs:llms:check
+npm run docs:publication-scope:check
 npm run build
 ```
 
@@ -104,8 +151,17 @@ npm run build
 
 ## 发布说明
 
-仓库中的 `.github/workflows/build.yml` 使用基于 tag 的自动发布流程。创建符合 `v*` 规则的
-标签并推送后，即可触发发布。
+仓库中的 `.github/workflows/publish-docs.yml` 会在 `main` 收到 push 后自动执行发布闭环：
+
+1. 生成并检查 `static/llms.txt`
+2. 运行公开范围检查
+3. 执行 lint、typecheck、Docusaurus build
+4. 部署 Cloudflare Pages
+5. 验证公开站点的 `/llms.txt`
+6. 刷新 Context7，或在缺少 secret / refresh 失败时留下可见 follow-up
+
+仓库仍保留 `.github/workflows/build.yml` 的 tag 发布流程，适合版本式 release。创建符合
+`v*` 规则的标签并推送后，即可触发该流程。
 
 ```bash
 git tag
@@ -117,3 +173,8 @@ Cloudflare Pages 相关自动部署仍依赖仓库环境中的：
 
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
+- `CONTEXT7_API_KEY`（用于自动刷新 Context7；缺失时 workflow 会保留 pending follow-up）
+
+可选仓库变量：
+
+- `CONTEXT7_LIBRARY_NAME`（默认使用 `/${{ github.repository }}` 形式的 Context7 library id）

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -27,8 +27,6 @@ related:
   - docs/agents/repo-validation.md
 ---
 
-# 开发环境配置
-
 本页说明 `tiangong-lca-next-docs` 的本地开发环境，以及它与产品仓
 `../tiangong-lca-next` 之间的 Node 基线关系。
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
@@ -1,5 +1,30 @@
 ---
 sidebar_position: 1
+title: Developer Environment
+docType: guide
+scope: repo
+status: active
+authoritative: true
+owner: next-docs
+language: en
+whenToUse:
+  - when setting up local next-docs development or validation commands
+  - when publishing docs, llms.txt, or Context7 source updates
+whenToUpdate:
+  - when package scripts, build commands, publish workflow, or publication-scope checks change
+checkPaths:
+  - package.json
+  - .github/workflows/build.yml
+  - .github/workflows/publish-docs.yml
+  - scripts/generate-llms-txt.mjs
+  - scripts/check-publication-scope.mjs
+  - context7.json
+  - static/llms.txt
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20f0a67cd7ec473f1d37fff4df534ea7fcb44349
+related:
+  - docs/dev/dev-env.md
+  - docs/agents/repo-validation.md
 ---
 
 # Developer Environment
@@ -57,6 +82,26 @@ The local site normally runs at `http://localhost:3000/`.
 npm run lint
 ```
 
+### Generate and check the AI docs index
+
+```bash
+npm run docs:llms
+npm run docs:llms:check
+```
+
+`docs:llms` generates `static/llms.txt` from the public Docusaurus docs. `docs:llms:check`
+confirms that the committed index still matches the current public-doc source.
+
+### Check publication scope
+
+```bash
+npm run docs:publication-scope:check
+```
+
+This command checks `static/llms.txt`, `sidebars.ts`, `context7.json`, and `build/llms.txt` when a
+build exists. It prevents internal agent docs, TODOs, plans, incident records, or governance
+execution material from entering the public AI-consumption scope.
+
 ### Auto-fix lintable Markdown issues
 
 ```bash
@@ -93,6 +138,8 @@ For public-doc content changes, run at least:
 
 ```bash
 npm run lint
+npm run docs:llms:check
+npm run docs:publication-scope:check
 npm run build
 ```
 
@@ -104,8 +151,18 @@ If your change touches navigation, sidebar structure, links, or bilingual mirror
 
 ## Release notes
 
-The repository's `.github/workflows/build.yml` uses a tag-triggered publish flow. Create and push a
-tag matching `v*` to trigger deployment.
+The repository's `.github/workflows/publish-docs.yml` runs the post-merge publish loop on every
+push to `main`:
+
+1. Generate and check `static/llms.txt`
+2. Run the publication-scope check
+3. Run lint, typecheck, and the Docusaurus build
+4. Deploy Cloudflare Pages
+5. Verify the public `/llms.txt`
+6. Refresh Context7, or leave a visible follow-up when the secret is missing or refresh fails
+
+The repository still keeps `.github/workflows/build.yml` for tag-triggered release publishing. Create
+and push a tag matching `v*` to trigger that flow.
 
 ```bash
 git tag
@@ -117,3 +174,8 @@ Cloudflare Pages deployment still depends on repository-level environment variab
 
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
+- `CONTEXT7_API_KEY` for automatic Context7 refresh. If it is missing, the workflow leaves a pending follow-up.
+
+Optional repository variable:
+
+- `CONTEXT7_LIBRARY_NAME`, defaulting to the Context7 library id form `/${{ github.repository }}`

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
@@ -27,8 +27,6 @@ related:
   - docs/agents/repo-validation.md
 ---
 
-# Developer Environment
-
 This page explains the local setup for `tiangong-lca-next-docs` and how its Node baseline relates to
 the product repo at `../tiangong-lca-next`.
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "docs:llms": "node scripts/generate-llms-txt.mjs",
+    "docs:llms:check": "node scripts/generate-llms-txt.mjs --check",
+    "docs:publication-scope:check": "node scripts/check-publication-scope.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -19,8 +22,8 @@
     "ncu:update": "npx npm-check-updates -u"
   },
   "dependencies": {
-    "@docusaurus/core": "3.9.2",
-    "@docusaurus/preset-classic": "3.9.2",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
@@ -31,9 +34,9 @@
     "remark-math": "^6.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/tsconfig": "3.9.2",
-    "@docusaurus/types": "3.9.2",
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/tsconfig": "3.10.1",
+    "@docusaurus/types": "3.10.1",
     "markdownlint-cli2": "^0.20.0",
     "npm-check-updates": "^19.3.2",
     "typescript": "~5.9.3"

--- a/scripts/check-publication-scope.mjs
+++ b/scripts/check-publication-scope.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  assertNoDeniedOutput,
+  collectPublicDocs,
+  llmsPath,
+  repoRoot,
+  validateContext7Config,
+  validateLlmsText,
+} from './publication-policy.mjs';
+
+const errors = [];
+
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    errors.push(`${name}: ${error.message}`);
+    console.error(`not ok - ${name}: ${error.message}`);
+  }
+}
+
+let docs = [];
+
+check('public docs allowlist', () => {
+  docs = collectPublicDocs();
+  if (docs.length === 0) {
+    throw new Error('no public docs were discovered');
+  }
+});
+
+check('static/llms.txt scope', () => {
+  if (!fs.existsSync(llmsPath)) {
+    throw new Error('static/llms.txt is missing; run npm run docs:llms');
+  }
+
+  validateLlmsText(fs.readFileSync(llmsPath, 'utf8'), docs);
+});
+
+check('Docusaurus sidebar scope', () => {
+  const sidebarPath = path.join(repoRoot, 'sidebars.ts');
+  assertNoDeniedOutput(fs.readFileSync(sidebarPath, 'utf8'), 'sidebars.ts');
+});
+
+check('Context7 source scope', () => {
+  validateContext7Config();
+});
+
+check('build output scope when present', () => {
+  const buildDir = path.join(repoRoot, 'build');
+  if (!fs.existsSync(buildDir)) {
+    console.log('skip - build output is not present yet');
+    return;
+  }
+
+  const buildLlmsPath = path.join(buildDir, 'llms.txt');
+  if (!fs.existsSync(buildLlmsPath)) {
+    throw new Error('build/llms.txt is missing after build');
+  }
+
+  validateLlmsText(fs.readFileSync(buildLlmsPath, 'utf8'), docs);
+});
+
+if (errors.length > 0) {
+  console.error('\nPublication scope check failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Publication scope check passed for ${docs.length} public docs.`);

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  collectPublicDocs,
+  getGitCommit,
+  llmsPath,
+  repoRoot,
+  validateLlmsText,
+} from './publication-policy.mjs';
+
+const args = new Set(process.argv.slice(2));
+const checkOnly = args.has('--check');
+
+function escapeLine(text) {
+  return String(text)
+    .replace(/\r?\n/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function plainText(text) {
+  return String(text)
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[`*_~<>]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncate(text, maxLength = 180) {
+  const normalized = escapeLine(plainText(text));
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength - 1).trim()}...`;
+}
+
+function renderLlmsText(docs) {
+  const commit = getGitCommit();
+  const lines = [
+    '# TianGong LCA Documentation',
+    '',
+    'Public documentation index for TianGong LCA users, integrators, and AI retrieval systems.',
+    '',
+    `Source site: https://docs.tiangong.earth`,
+    `Source repository: https://github.com/linancn/tiangong-lca-next-docs`,
+    `Source commit: ${commit}`,
+    'Publication scope: public Docusaurus docs only. Internal agent, plan, incident, TODO, and governance execution records are excluded.',
+    '',
+  ];
+
+  const locales = [...new Set(docs.map((doc) => doc.locale))].sort();
+  for (const locale of locales) {
+    const localeDocs = docs.filter((doc) => doc.locale === locale);
+    const localeLabel = localeDocs[0]?.localeLabel || locale;
+
+    lines.push(`## ${localeLabel} (${locale})`);
+    lines.push('');
+
+    for (const doc of localeDocs) {
+      const description = truncate(doc.description);
+      const suffix = description ? ` - ${description}` : '';
+      lines.push(`- [${escapeLine(doc.title)}](${doc.url})${suffix}`);
+    }
+
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trim()}\n`;
+}
+
+function firstDifference(expected, actual) {
+  const expectedLines = expected.split('\n');
+  const actualLines = actual.split('\n');
+  const maxLines = Math.max(expectedLines.length, actualLines.length);
+
+  for (let index = 0; index < maxLines; index += 1) {
+    if (expectedLines[index] !== actualLines[index]) {
+      return {
+        line: index + 1,
+        expected: expectedLines[index] ?? '<missing>',
+        actual: actualLines[index] ?? '<missing>',
+      };
+    }
+  }
+
+  return null;
+}
+
+function normalizeForCheck(text) {
+  return text.replace(/^Source commit: .+$/m, 'Source commit: <normalized>');
+}
+
+const docs = collectPublicDocs();
+const generated = renderLlmsText(docs);
+validateLlmsText(generated, docs);
+
+if (checkOnly) {
+  if (!fs.existsSync(llmsPath)) {
+    console.error(`Missing ${path.relative(repoRoot, llmsPath)}. Run npm run docs:llms.`);
+    process.exit(1);
+  }
+
+  const current = fs.readFileSync(llmsPath, 'utf8');
+  if (normalizeForCheck(current) !== normalizeForCheck(generated)) {
+    const diff = firstDifference(normalizeForCheck(generated), normalizeForCheck(current));
+    console.error(`${path.relative(repoRoot, llmsPath)} is out of date. Run npm run docs:llms.`);
+    if (diff) {
+      console.error(`First difference at line ${diff.line}:`);
+      console.error(`  expected: ${diff.expected}`);
+      console.error(`  actual:   ${diff.actual}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`${path.relative(repoRoot, llmsPath)} is up to date (${docs.length} docs).`);
+  process.exit(0);
+}
+
+fs.mkdirSync(path.dirname(llmsPath), {recursive: true});
+fs.writeFileSync(llmsPath, generated);
+console.log(`Generated ${path.relative(repoRoot, llmsPath)} with ${docs.length} public docs.`);

--- a/scripts/publication-policy.mjs
+++ b/scripts/publication-policy.mjs
@@ -1,0 +1,334 @@
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+export const repoRoot = path.resolve(scriptDir, '..');
+export const defaultSiteUrl = 'https://docs.tiangong.earth';
+export const llmsPath = path.join(repoRoot, 'static', 'llms.txt');
+
+export const publicDocSources = [
+  {
+    locale: 'zh-CN',
+    label: 'Chinese',
+    root: 'docs',
+    routePrefix: '',
+  },
+  {
+    locale: 'en',
+    label: 'English',
+    root: 'i18n/en/docusaurus-plugin-content-docs/current',
+    routePrefix: '/en',
+  },
+];
+
+const deniedPathPatterns = [
+  /(^|\/)_docs(\/|$)/,
+  /(^|\/)_docs\/plans(\/|$)/,
+  /(^|\/)_docs\/incidents(\/|$)/,
+  /(^|\/)_docs\/runbooks(\/|$)/,
+  /(^|\/)\.agents(\/|$)/,
+  /(^|\/)\.docpact\/runs(\/|$)/,
+  /(^|\/)docs\/agents(\/|$)/,
+  /(^|\/)AGENTS\.md$/,
+  /(^|\/)TODO(?:\.|$)/,
+  /(^|\/)node_modules(\/|$)/,
+  /(^|\/)build(\/|$)/,
+  /(^|\/)\.docusaurus(\/|$)/,
+];
+
+const deniedOutputFragments = [
+  '_docs/',
+  '.agents/',
+  '.docpact/runs/',
+  'docs/agents/',
+  'AGENTS.md',
+  'TODO.docs-system-gaps',
+  'not-for-publication',
+  'agent-runbook',
+];
+
+const deniedFrontmatterValues = new Set([
+  'draft',
+  'internal',
+  'incident',
+  'plan',
+  'private',
+  'not-for-publication',
+  'agent-runbook',
+]);
+
+export function toPosix(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+export function relativeToRepo(filePath) {
+  return toPosix(path.relative(repoRoot, filePath));
+}
+
+export function getGitCommit() {
+  if (process.env.GITHUB_SHA) {
+    return process.env.GITHUB_SHA;
+  }
+
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function isDeniedPath(relativePath) {
+  return deniedPathPatterns.some((pattern) => pattern.test(relativePath));
+}
+
+export function assertNoDeniedOutput(text, label) {
+  const hits = deniedOutputFragments.filter((fragment) => text.includes(fragment));
+
+  if (hits.length > 0) {
+    throw new Error(`${label} contains denied publication fragments: ${hits.join(', ')}`);
+  }
+}
+
+export function parseFrontmatter(content) {
+  if (!content.startsWith('---\n')) {
+    return {};
+  }
+
+  const end = content.indexOf('\n---', 4);
+  if (end === -1) {
+    return {};
+  }
+
+  const frontmatter = {};
+  const body = content.slice(4, end);
+
+  for (const line of body.split('\n')) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    const [, key, rawValue] = match;
+    frontmatter[key] = rawValue.trim().replace(/^['"]|['"]$/g, '');
+  }
+
+  return frontmatter;
+}
+
+export function stripFrontmatter(content) {
+  if (!content.startsWith('---\n')) {
+    return content;
+  }
+
+  const end = content.indexOf('\n---', 4);
+  if (end === -1) {
+    return content;
+  }
+
+  return content.slice(end + 4).trimStart();
+}
+
+export function assertPublishableFrontmatter(frontmatter, relativePath) {
+  const blockedKeys = ['draft', 'internal', 'private', 'not-for-publication'];
+
+  for (const key of blockedKeys) {
+    const value = String(frontmatter[key] ?? '').toLowerCase();
+    if (value === 'true' || value === 'yes' || value === '1') {
+      throw new Error(`${relativePath} is marked ${key} and cannot be published`);
+    }
+  }
+
+  for (const key of ['status', 'docType', 'publication', 'visibility']) {
+    const value = String(frontmatter[key] ?? '').toLowerCase();
+    if (deniedFrontmatterValues.has(value)) {
+      throw new Error(`${relativePath} has denied ${key}: ${frontmatter[key]}`);
+    }
+  }
+}
+
+export function listFilesRecursive(rootDir) {
+  if (!fs.existsSync(rootDir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(rootDir, {withFileTypes: true});
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursive(entryPath));
+    } else {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function isMarkdownDoc(filePath) {
+  return /\.(md|mdx)$/.test(filePath) && !path.basename(filePath).startsWith('_');
+}
+
+function normalizeSlug(slug) {
+  if (!slug) {
+    return null;
+  }
+
+  const withLeadingSlash = slug.startsWith('/') ? slug : `/${slug}`;
+  return withLeadingSlash.replace(/\/+/g, '/');
+}
+
+function routeFromPath(source, sourceRelativePath) {
+  let routePath = sourceRelativePath.replace(/\.(md|mdx)$/, '');
+
+  if (routePath === 'intro') {
+    routePath = '';
+  } else if (routePath.endsWith('/index')) {
+    routePath = routePath.slice(0, -'/index'.length);
+  }
+
+  return normalizeSlug(`${source.routePrefix}/${routePath}`);
+}
+
+export function routeForDoc(source, sourceRelativePath, frontmatter) {
+  const slug = normalizeSlug(frontmatter.slug);
+  if (slug) {
+    if (!source.routePrefix) {
+      return slug;
+    }
+
+    return slug === '/' ? `${source.routePrefix}/` : normalizeSlug(`${source.routePrefix}${slug}`);
+  }
+
+  return routeFromPath(source, sourceRelativePath);
+}
+
+export function absoluteDocUrl(routePath) {
+  const siteUrl = (process.env.DOCS_SITE_URL || defaultSiteUrl).replace(/\/$/, '');
+  return `${siteUrl}${routePath}`;
+}
+
+function firstHeading(markdownBody) {
+  const heading = markdownBody.match(/^#\s+(.+)$/m);
+  return heading?.[1]?.trim() || null;
+}
+
+function firstParagraph(markdownBody) {
+  const bodyWithoutHeadings = markdownBody
+    .split('\n')
+    .filter((line) => !line.startsWith('#'))
+    .join('\n')
+    .trim();
+  const paragraph = bodyWithoutHeadings
+    .split(/\n\s*\n/)
+    .map((part) => part.replace(/\s+/g, ' ').trim())
+    .find((part) => part && !part.startsWith('```') && !part.startsWith('|'));
+
+  return paragraph || '';
+}
+
+export function collectPublicDocs() {
+  const docs = [];
+
+  for (const source of publicDocSources) {
+    const absoluteRoot = path.join(repoRoot, source.root);
+    const files = listFilesRecursive(absoluteRoot).filter(isMarkdownDoc);
+
+    for (const file of files) {
+      const repoRelativePath = relativeToRepo(file);
+      if (isDeniedPath(repoRelativePath)) {
+        continue;
+      }
+
+      const sourceRelativePath = toPosix(path.relative(absoluteRoot, file));
+      const content = fs.readFileSync(file, 'utf8');
+      const frontmatter = parseFrontmatter(content);
+      assertPublishableFrontmatter(frontmatter, repoRelativePath);
+
+      const body = stripFrontmatter(content);
+      const title = frontmatter.title || firstHeading(body) || sourceRelativePath.replace(/\.(md|mdx)$/, '');
+      const description = frontmatter.description || firstParagraph(body);
+      const routePath = routeForDoc(source, sourceRelativePath, frontmatter);
+
+      docs.push({
+        locale: source.locale,
+        localeLabel: source.label,
+        path: repoRelativePath,
+        routePath,
+        title,
+        description,
+        url: absoluteDocUrl(routePath),
+      });
+    }
+  }
+
+  return docs.sort((a, b) => {
+    if (a.locale !== b.locale) {
+      return a.locale.localeCompare(b.locale);
+    }
+
+    return a.routePath.localeCompare(b.routePath);
+  });
+}
+
+export function validateContext7Config() {
+  const configPath = path.join(repoRoot, 'context7.json');
+  if (!fs.existsSync(configPath)) {
+    throw new Error('context7.json is required for Context7 publication scope control');
+  }
+
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  const folders = new Set(config.folders || []);
+  const excludeFolders = new Set(config.excludeFolders || []);
+  const excludeFiles = new Set(config.excludeFiles || []);
+
+  for (const source of publicDocSources) {
+    if (!folders.has(source.root)) {
+      throw new Error(`context7.json folders must include ${source.root}`);
+    }
+  }
+
+  for (const folder of ['docs/agents', '.agents', '.docpact', '_docs', 'build', 'node_modules']) {
+    if (!excludeFolders.has(folder)) {
+      throw new Error(`context7.json excludeFolders must include ${folder}`);
+    }
+  }
+
+  for (const file of ['AGENTS.md', 'README.md', 'TODO.docs-system-gaps.md']) {
+    if (!excludeFiles.has(file)) {
+      throw new Error(`context7.json excludeFiles must include ${file}`);
+    }
+  }
+
+  return config;
+}
+
+export function validateLlmsText(text, docs) {
+  assertNoDeniedOutput(text, 'static/llms.txt');
+
+  const allowedOrigin = new URL(process.env.DOCS_SITE_URL || defaultSiteUrl).origin;
+  const allowedPaths = new Set(docs.map((doc) => new URL(doc.url).pathname.replace(/\/$/, '') || '/'));
+  const linkPattern = /\]\((https?:\/\/[^)]+)\)/g;
+  const badLinks = [];
+  let match;
+
+  while ((match = linkPattern.exec(text)) !== null) {
+    const url = new URL(match[1]);
+    const normalizedPath = url.pathname.replace(/\/$/, '') || '/';
+    if (url.origin !== allowedOrigin || !allowedPaths.has(normalizedPath)) {
+      badLinks.push(match[1]);
+    }
+  }
+
+  if (badLinks.length > 0) {
+    throw new Error(`static/llms.txt contains links outside the public docs allowlist: ${badLinks.join(', ')}`);
+  }
+}

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,84 @@
+# TianGong LCA Documentation
+
+Public documentation index for TianGong LCA users, integrators, and AI retrieval systems.
+
+Source site: https://docs.tiangong.earth
+Source repository: https://github.com/linancn/tiangong-lca-next-docs
+Source commit: 20f0a67cd7ec473f1d37fff4df534ea7fcb44349
+Publication scope: public Docusaurus docs only. Internal agent, plan, incident, TODO, and governance execution records are excluded.
+
+## English (en)
+
+- [Introduction](https://docs.tiangong.earth/en/) - TianGong LCA is an open-source LCA data platform built upon the TIDAS (TIangong DAta System) data system. The platform offers flexible usage options, allowing users to either acce...
+- [Feature Updates](https://docs.tiangong.earth/en/changelog/function-update) - Track the evolution of TianGong LCA: each entry lists the release date, new capability, and the guide you should read to adopt it.
+- [Data Evaluation](https://docs.tiangong.earth/en/data-collection/case-introduction/data-evaluation) - For data collection guidelines, refer to Data Collection Instructions
+- [Partially Terminated System Modeling](https://docs.tiangong.earth/en/data-collection/case-introduction/model-building) - This section should outline the overall system structure composed of three unit processes and briefly explain their integration in the lifecycle model. The corresponding lifecycle...
+- [Unit Process Construction](https://docs.tiangong.earth/en/data-collection/case-introduction/unit-process-construction) - Reference for platform operations: Create New Data - Create Process
+- [Data Collection Guidelines](https://docs.tiangong.earth/en/data-collection/data-collection-instructions) - This document outlines general principles, sources, procedures and quality control requirements for data collection.
+- [Self-Hosting Guide](https://docs.tiangong.earth/en/deploy/local-deploy) - This document provides instructions for self-hosting the Tiangong LCA application using Docker. The setup includes both the Tiangong LCA Next application and a complete Supabase b...
+- [Developer Environment](https://docs.tiangong.earth/en/dev/dev-env) - This page explains the local setup for tiangong-lca-next-docs and how its Node baseline relates to the product repo at ../tiangong-lca-next.
+- [Docs / Product Sync Guide](https://docs.tiangong.earth/en/dev/docs-product-sync) - Explain how maintainers should keep the docs site aligned with the tiangong-lca-next product repo, including source boundaries, verification workflow, and screenshot rules.
+- [TIDAS Package Import API](https://docs.tiangong.earth/en/docs/openapi/tidas-package-import) - Import TIDAS ZIP packages through the TianGong LCA API with API key authentication.
+- [Commercial Database Access](https://docs.tiangong.earth/en/faq/commercial-database) - For inquiries regarding HiQLCD database access, please contact us through the following channels:
+- [Registration and Login](https://docs.tiangong.earth/en/faq/email-verification) - Alternative text
+- [Terminology Explanation](https://docs.tiangong.earth/en/faq/explanation) - Example: Company A commissions Research Institute B to carry out a life cycle assessment project. The research team (Team C) is responsible for generating the data, and the datase...
+- [Sources & Citation](https://docs.tiangong.earth/en/faq/sources-and-citation) - Ensure TianGong LCA datasets remain traceable and properly referenced.
+- [System Modelling](https://docs.tiangong.earth/en/faq/system-models) - Answers about building models in TianGong LCA and how it compares with other LCA tools.
+- [TianGong Knowledge Base MCP](https://docs.tiangong.earth/en/MCP/KB_remote) - Check the TianGong MCP Hub for updated knowledge-base tooling guides, scripts, and FAQs. The essentials are summarised below.
+- [TianGong LCA MCP (Local)](https://docs.tiangong.earth/en/MCP/lca_local) - Visit the TianGong MCP Hub for the latest plug-in samples, configuration scripts, and FAQs. This page summarises the key steps for local deployment.
+- [TianGong LCA MCP (Remote)](https://docs.tiangong.earth/en/MCP/lca_remote) - For the latest release notes, tooling samples, and integration tips, visit the TianGong MCP Hub. This page highlights the essentials for using the remote service.
+- [Operation demonstration](https://docs.tiangong.earth/en/quick-start/demonstrations) - Demonstrate the usage process of the platform through an example dataset:
+- [User Sign up and Login Guide](https://docs.tiangong.earth/en/quick-start/first-login) - Welcome to this guide! Below are instructions on how to quickly sign up for a new account or log in to an existing one.
+- [Resources and Support](https://docs.tiangong.earth/en/resources-and-support) - The TianGong LCA platform provides comprehensive resources and support to ensure that you can use the system efficiently and maximize its potential. We offer a variety of learning...
+- [Account Management & API Key](https://docs.tiangong.earth/en/user-guide/account-profile) - Open the avatar menu in the top-right corner and select Account Profile to reach the account page.
+- [Create My Data](https://docs.tiangong.earth/en/user-guide/create-my-data) - Follow the Prepare → Build → Data validation flow to create processes, models, flows, and supporting references in “My Data”.
+- [Data Platform Overview](https://docs.tiangong.earth/en/user-guide/data) - Use this page to understand the scope, permissions, and typical usage of each data module before diving into creation or review work.
+- [Data Review](https://docs.tiangong.earth/en/user-guide/data-review) - Data review is no longer just “submit and wait.” It involves distinct workspaces and responsibilities for authors, review members, and review admins. This page is organised as pre...
+- [Data Usage Guide](https://docs.tiangong.earth/en/user-guide/data-use) - 1. Open Data Panel: Locate the left navigation bar and click "Open Data" or "Commercial Data" to activate the data management interface. 2. Navigate Process Directory: Select targ...
+- [Key Functions Overview](https://docs.tiangong.earth/en/user-guide/key-functions-introduction) - This guide groups the most important interface controls by scenario. If you are looking for the ZIP package workflow specifically, continue with TIDAS ZIP Import, Export, and Task...
+- [LCIA Calculation & Results](https://docs.tiangong.earth/en/user-guide/lcia) - This page covers the two common LCIA usage patterns in TianGong LCA:
+- [User Guide Map](https://docs.tiangong.earth/en/user-guide/overview) - Orient different roles to the right TianGong LCA tutorials and best practices.
+- [Permissions & Data Spaces](https://docs.tiangong.earth/en/user-guide/permissions-and-data-scopes) - Consolidate the main access boundaries for Open Data, Commercial Data, My Data, Team Data, review roles, and system roles.
+- [Process Analysis Workspace](https://docs.tiangong.earth/en/user-guide/process-analysis) - Explain the LCA Analysis workspace in My Data → Processes, including profile, comparison, grouped results, and contribution-path analysis.
+- [Data Search](https://docs.tiangong.earth/en/user-guide/search) - The TianGong LCA Platform provides powerful full-text search capabilities, supporting cross-field searches across all data modules. This feature gives TianGong LCA Platform signif...
+- [System Management Workspace](https://docs.tiangong.earth/en/user-guide/system-management) - Explain the system-role workspace for homepage team display management and system member management.
+- [Team Functions](https://docs.tiangong.earth/en/user-guide/team-function) - Team workspaces centralise shared datasets, enforce permissions, and streamline collaboration. This page explains why teams matter, how to join or create one, and what each role c...
+- [TIDAS ZIP Import, Export, and Task Center](https://docs.tiangong.earth/en/user-guide/tidas-zip-workflows) - Explain the top-bar TIDAS ZIP workflows and how asynchronous jobs appear in the shared task center.
+
+## Chinese (zh-CN)
+
+- [简介](https://docs.tiangong.earth/) - TianGong LCA 是一个基于 TIDAS（TIangong DAta System）数据系统的开源LCA数据平台。该平台提供灵活的使用方式，用户既可选择在线系统，也可在本地进行私有化部署。TianGong LCA平台支持多团队多用户协作，团队成员可以共同执行复杂的LCA数据制备项目。
+- [功能更新](https://docs.tiangong.earth/changelog/function-update) - 追踪 TianGong LCA 的功能迭代与重要改动，便于了解新能力、生效日期及关联的使用文档。
+- [数据评估](https://docs.tiangong.earth/data-collection/case-introduction/data-evaluation) - 数据收集指南可参考 数据收集-数据收集说明
+- [部分终止系统建模](https://docs.tiangong.earth/data-collection/case-introduction/model-building) - 此部分基础信息应概述由三个单元过程构成的整体系统结构，并简要说明它们在生命周期模型中的集成方式。对应的生命周期模型图也应展示这三个单元过程的连接关系，反映出系统边界内的完整物质与能量流动路径。
+- [单元过程构建](https://docs.tiangong.earth/data-collection/case-introduction/unit-process-construction) - 新建单元过程的平台操作流程参考新建数据-新建过程
+- [数据收集说明](https://docs.tiangong.earth/data-collection/data-collection-instructions) - 本文档用于说明数据收集工作的通用原则、来源渠道、操作流程及质量控制要求。
+- [私有部署](https://docs.tiangong.earth/deploy/local-deploy) - 本文档提供使用 Docker 私有部署 TianGong LCA 应用的说明。该设置包括 TianGong LCA Next 应用以及完整的 Supabase 后端。
+- [开发环境配置](https://docs.tiangong.earth/dev/dev-env) - 本页说明 tiangong-lca-next-docs 的本地开发环境，以及它与产品仓 ../tiangong-lca-next 之间的 Node 基线关系。
+- [Docs / Product 同步指南](https://docs.tiangong.earth/dev/docs-product-sync) - 为维护者说明 docs 站点如何与 tiangong-lca-next 产品仓保持同步，包括来源边界、验证方式和截图规范。
+- [TIDAS 数据包导入 API](https://docs.tiangong.earth/docs/openapi/tidas-package-import) - 使用 API Key 调用 TianGong LCA 的 TIDAS 数据包导入流程。
+- [商业数据库获取](https://docs.tiangong.earth/faq/commercial-database) - 如您需获取HiQLCD数据库事宜，请通过以下指定方式联络：
+- [注册与登录](https://docs.tiangong.earth/faq/email-verification) - 替代文字
+- [名词解释](https://docs.tiangong.earth/faq/explanation) - 示例：某公司(CompanyA)委托研究机构(Research Institute B)开展一个生命周期评估项目。研究人员团队(TeamC)负责生成数据，并由该团队成员(Person D)录入数据集信息。数据完成后，由国际环境数据库协会(IEDA)进行注册备案。最终数据的所有权归公司(CompanyA)，但只有公司内部研究小组(Group E)可以排他性访...
+- [数据来源与引用](https://docs.tiangong.earth/faq/sources-and-citation) - 规范 TianGong LCA 数据的引用方式，提升溯源透明度。
+- [系统建模](https://docs.tiangong.earth/faq/system-models) - 回答在 TianGong LCA 中构建模型时与其他 LCA 软件的差异及注意事项。
+- [天工知识库MCP](https://docs.tiangong.earth/MCP/KB_remote) - 如需查看知识库工具的最新说明、示例与常见问题，可访问天工MCP Hub。
+- [天工LCA MCP（本地）](https://docs.tiangong.earth/MCP/lca_local) - 访问天工MCP Hub获取最新插件示例、配置脚本与常见问题说明，下文概述本地部署的关键步骤。
+- [天工LCA MCP（远程）](https://docs.tiangong.earth/MCP/lca_remote) - 更多发布说明和工具示例可参阅天工MCP Hub，该站点持续更新远程服务的配置注意事项。
+- [操作演示](https://docs.tiangong.earth/quick-start/demonstrations) - 通过示例数据集展示平台的使用流程:
+- [用户注册与登录指南](https://docs.tiangong.earth/quick-start/first-login) - 欢迎使用本指南！以下是如何快速注册新账户或登录已有账户的说明。
+- [资源与支持](https://docs.tiangong.earth/resources-and-support) - 天工LCA平台的开发与构建依托天工计划，基于 TIDAS（TIangong DAta System）数据系统，遵循生命周期评价（LCA）的基本原则和框架。
+- [账号管理与 API Key](https://docs.tiangong.earth/user-guide/account-profile) - 点击右上角头像或用户名，选择账号信息，即可进入账户页。
+- [数据新建](https://docs.tiangong.earth/user-guide/create-my-data) - 按照准备→建模→验证的流程，在“我的数据”模块中创建过程、模型、流及配套信息。
+- [数据平台介绍](https://docs.tiangong.earth/user-guide/data) - 本文帮助您从宏观角度理解 TianGong LCA 数据模块的定位、权限差异与常见用法，为后续的数据新建和数据审核做准备。
+- [数据审核](https://docs.tiangong.earth/user-guide/data-review) - 数据审核不仅是“提交并等待结果”，还涉及提交者、审核成员、审核管理员之间的不同工作区和职责。 本页按提交前准备 → 角色分工 → 审核工作区 → 常见问题展开说明。
+- [数据使用](https://docs.tiangong.earth/user-guide/data-use) - 1. 展开数据面板：定位左侧导航栏，单击“开放数据”或“商业数据”，激活数据管理界面。 2. 定位过程目录：在分级列表中选中目标条目，页面跳转至相应数据空间。 3. 查看数据：点击相应数据列表右侧的“查看”键，可查看数据的全维度信息。包含地理位置坐标、时间戳范围、系统边界、输入输出清单、所属行业与产品等。 4. 查看历史版本：在数据集列表点击“所有版本”键...
+- [按键功能介绍](https://docs.tiangong.earth/user-guide/key-functions-introduction) - 本文按使用场景归纳界面中的常用按钮，重点覆盖顶部全局控件、数据列表操作以及协作入口。 如果您要处理 TIDAS ZIP 数据包，请继续阅读 TIDAS ZIP 导入、导出与任务中心。
+- [LCIA 计算与结果查看](https://docs.tiangong.earth/user-guide/lcia) - 本页说明 TianGong LCA 中两类常见的 LCIA（生命周期影响评价）使用方式：
+- [用户指南导航](https://docs.tiangong.earth/user-guide/overview) - 帮助不同角色快速定位到 TianGong LCA 用户文档中的操作指南与最佳实践。
+- [权限与数据空间矩阵](https://docs.tiangong.earth/user-guide/permissions-and-data-scopes) - 汇总 Open Data、Commercial Data、My Data、Team Data，以及审核角色和系统角色的主要权限边界。
+- [过程分析工作区](https://docs.tiangong.earth/user-guide/process-analysis) - 说明“我的数据 → 过程”中的 LCA Analysis 工作区，包括过程画像、影响比较、分组结果和贡献路径分析。
+- [数据搜索](https://docs.tiangong.earth/user-guide/search) - 天工LCA平台提供强大的全文搜索功能，支持在所有数据模块中进行跨字段搜索。这一特性使天工LCA平台在数据检索能力上显著优于其他LCA平台。
+- [系统管理工作区](https://docs.tiangong.earth/user-guide/system-management) - 说明系统角色可见的系统管理工作区，包括展示管理与成员管理。
+- [团队功能介绍](https://docs.tiangong.earth/user-guide/team-function) - 团队功能承载数据共享、权限控制与协作工作流。本节概述团队类型、邀请流程以及不同角色可以执行的操作，并提供常见问题排查指南。
+- [TIDAS ZIP 导入、导出与任务中心](https://docs.tiangong.earth/user-guide/tidas-zip-workflows) - 说明顶部全局入口中的 TIDAS ZIP 导入、导出，以及任务中心中的异步任务处理方式。


### PR DESCRIPTION
Closes #41

## Summary
- Add a main-push Docusaurus publish workflow that builds, deploys to Cloudflare Pages, verifies /llms.txt, and refreshes Context7 or records a visible pending/blocker follow-up.
- Generate static/llms.txt from the public Docusaurus allowlist and add docs:llms, docs:llms:check, and docs:publication-scope:check npm scripts.
- Add context7.json and publication-scope checks so internal agent docs, TODOs, plans, incidents, and governance records stay out of public AI-consumption scope.

## Key Decisions
- Use a fork branch because the current token has READ permission on the canonical next-docs repository.
- Upgrade Docusaurus packages to 3.10.1 because npm install without a lockfile pulled webpack 5.106.2 and Docusaurus 3.9.2 failed build-time ProgressPlugin validation.

## Validation
- npm run lint
- npm run docs:llms:check
- npm run docs:publication-scope:check before and after build
- npm run typecheck
- npm run build
- node --check for new .mjs scripts and YAML parse for publish-docs.yml
- docpact validate-config --root . --strict
- docpact lint --root . --staged --mode enforce

## Risks / Rollback
- Cloudflare publish still depends on CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID repository secrets.
- Context7 refresh depends on CONTEXT7_API_KEY and optional CONTEXT7_LIBRARY_NAME; missing Context7 secret records a pending follow-up after publish instead of silently succeeding.

## Workspace Integration
- After this next-docs PR merges, lca-workspace should deliberately bump the tiangong-lca-next-docs submodule pointer in a separate root integration step.