### PR TITLE
chore: gate docs deploy release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,33 @@ on:
       - 'v*'
 
 jobs:
+  release-gate:
+    name: Release Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint docs
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
   release:
+    needs: release-gate
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Closes linancn/tiangong-lca-next-docs#50

## Summary
- Add a release-gate job before Cloudflare Pages release deploy.
- Run lint, typecheck, and build as the precondition for v* tag and release-event deploys.

## Key Decisions
- Keep ordinary pushes free of standalone remote test gates; release/deploy workflows own release validation.

## Validation
- docpact gate passed during push.
- YAML parse, shell syntax, and staged diff checks passed locally before commit.

## Risks / Rollback
- Release deploy now waits for the build gate before deploying.

## Workspace Integration
- Requires lca-workspace submodule pointer update after merge.