### PR TITLE
Gate docs releases with local doc checks

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 77fb69cdd95f467f5f4841cf8e0b42b451dba3ce
+lastReviewedAt: "2026-05-28"
+lastReviewedCommit: "6381555ed311a235654e7409917562aa5e1fcca0"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,7 +1,7 @@
 name: ai-doc-lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,19 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
         run: cargo install docpact --version 0.1.9 --force
 
-      - name: Validate docpact config
-        run: scripts/docpact validate-config --root . --strict
-
-      - name: Run ai-doc-lint
-        run: |
-          scripts/docpact lint \
-            --root . \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head "${{ github.event.pull_request.head.sha }}" \
-            --mode enforce
+      - name: Run local docpact gate
+        run: scripts/docpact-gate.sh --base origin/main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,25 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install docpact
+        run: cargo install docpact --version 0.1.9 --force
 
       - name: Set up Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Run docpact release gate
+        run: scripts/docpact-gate.sh --base origin/main
 
       - name: Install dependencies
         run: npm install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
-- Repo-local documentation governance is enforced through `.docpact/config.yaml` and `.github/workflows/ai-doc-lint.yml`.
+- Repo-local documentation governance is encoded in `.docpact/config.yaml` and enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback.
 - Chinese docs are the source of truth for this site; English pages are maintained mirrors and must be updated in the same change
 - The canonical local commands are `npm run lint`, `npm run build`, and `npm run typecheck`
 - Use Playwright or equivalent product verification only when text inspection of `../tiangong-lca-next` is not enough to confirm the current UI flow or screenshot target

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -59,4 +59,4 @@ A merged PR in this repository is repo-complete only. If the updated docs site s
 
 ## Local Docpact Push Gate
 
-This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.
+This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; ordinary PRs and pushes rely on the local gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback for remote reproduction.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -64,7 +64,7 @@ scripts/docpact validate-config --root . --strict
 scripts/docpact lint --root . --base origin/main --head HEAD --mode enforce
 ```
 
-The repository PR workflow runs the same docpact config validation and PR-shaped lint gate.
+The manual `ai-doc-lint` workflow delegates to the same local docpact gate when remote reproduction is needed.
 
 ## Local Docpact Push Gate
 


### PR DESCRIPTION
## Summary
- move ai-doc-lint off ordinary PR/push execution and keep it as manual fallback
- keep documentation governance in the local pre-push gate
- add a docpact release gate before Cloudflare Pages deploy

## Validation
- parsed changed GitHub workflow YAML locally
- ran repo docpact/AI-doc gate against origin/main..HEAD
- ran local test gate where the repo pre-push hook required it

Closes #52
