### PR TITLE
[TEST docs-impact replay] 补充外部 LCA 格式导入准备说明

### DIFF
--- a/docs/user-guide/tidas-zip-workflows.md
+++ b/docs/user-guide/tidas-zip-workflows.md
@@ -34,6 +34,12 @@ description: 说明顶部全局入口中的 TIDAS ZIP 导入、导出，以及�
 - 非 ZIP 文件会被系统直接拒绝
 - 导入前系统会执行结构校验、引用校验和冲突检查
 
+### 外部 LCA 格式需先转换
+
+网页端导入入口只接收已经整理成 TIDAS 结构的 ZIP 数据包。如果原始数据来自 EcoSpold 1、
+EcoSpold 2、openLCA JSON-LD、SimaPro CSV 或 openLCA process XLSX 等外部 LCA 格式，请先使用
+TIDAS 工具链转换并校验生成的 TIDAS 包，再回到网页端上传生成的 ZIP 文件。
+
 ### 导入步骤
 
 1. 点击顶部工具条中的**导入 TIDAS ZIP 数据包**。

--- a/i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md
@@ -35,6 +35,13 @@ If you need the broader control map first, start with
 - Non-ZIP files are rejected immediately
 - The system validates structure, references, and conflicts before import
 
+### Convert external LCA formats first
+
+The web import entry accepts ZIP packages that already follow the TIDAS structure. If the original
+data comes from external LCA formats such as EcoSpold 1, EcoSpold 2, openLCA JSON-LD, SimaPro CSV,
+or openLCA process XLSX, use the TIDAS tooling to convert and validate the generated TIDAS package
+first, then upload the resulting ZIP file in the web UI.
+
 ### Import steps
 
 1. Click **Import TIDAS ZIP Package** in the top bar.


### PR DESCRIPTION
<!-- docs-impact-local-replay-mapped:v1
{
  "docsImpactIssue": "tiangong-lca/workspace#175",
  "localWorker": true,
  "stage": "replay",
  "governancePullRequest": "tiangong-lca/workspace#176",
  "governancePullRequestUrl": "https://github.com/tiangong-lca/workspace/pull/176",
  "governanceMergeCommit": "6c75935f2e862a7c6fb0cb037f8cb4ecf52f348f",
  "governanceMergedAt": "2026-05-28T02:12:27Z",
  "sourcePullRequests": [
    "linancn/tiangong-lca-next#425",
    "tiangong-lca/database-engine#54",
    "linancn/tiangong-lca-next#427",
    "tiangong-lca/tidas-tools#60",
    "tiangong-lca/tidas-tools#62"
  ],
  "ruleIds": [
    "user-docs-national-carbon-dashboard",
    "user-docs-data-catalog-reference",
    "user-docs-tidas-package-workflow"
  ],
  "decisionValidation": "pass",
  "docPlacementValidation": "pass",
  "testRun": true
}
-->

## 摘要

[TEST docs-impact] 根据 docs-impact #175 的 replay worker 结果，补充 TIDAS ZIP 导入文档中外部 LCA 源格式的准备边界。此 PR 仅用于 48 小时真实 watermark replay 流程测试，保持 Draft，第一轮不合并。

## 变更

- 在中文 TIDAS ZIP 工作流中说明：网页端只接收 TIDAS 结构 ZIP，EcoSpold/openLCA/SimaPro 等外部 LCA 格式需先用 TIDAS 工具链转换并校验。
- 在英文 mirror 中补充同等说明。
- 将 data latest-version 与 NationalCarbonDashboard replay 命中记录为 noop，避免和 mapped docs PR #49 重复或过度声明隐藏路由。

## 验证

- `validate-pre-change-decision.rb --stage replay`: pass
- `validate-doc-placement.rb --stage replay`: pass
- `npx markdownlint-cli2 docs/user-guide/tidas-zip-workflows.md i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md`: pass
- `npm run build`: pass，使用 Node 20.18.1，并在无 lockfile 的本地 `node_modules` 中临时安装 `webpack@5.95.0`
- `npm run lint`: fail，既有 `docs/agents/repo-architecture.md` 和 `docs/agents/repo-validation.md` 多 H1，非本次改动

Refs tiangong-lca/workspace#175
Refs tiangong-lca/workspace#176

<!-- docs-impact-pre-change-summary:start -->
# Docs Impact #175 replay worker pre-change decision

## Metadata required doc coverage

The decision summary covers these metadata required docs:

- `tiangong-lca-next-docs/docs/user-guide/key-functions-introduction.md`
- `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/key-functions-introduction.md`
- `tiangong-lca-next-docs/docs/user-guide/lcia.md`
- `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/lcia.md`
- `tiangong-lca-next-docs/docs/faq/system-models.md`
- `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md`
- `tiangong-lca-next-docs/docs/user-guide/process-analysis.md`
- `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md`
- `tiangong-lca-next-docs/docs/user-guide/create-my-data.md`
- `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md`
- `tiangong-lca-next-docs/docs/user-guide/data-use.md`
- `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md`
- `tiangong-lca-next-docs/docs/user-guide/data.md`
- `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/data.md`
- `tiangong-lca-next-docs/docs/user-guide/tidas-zip-workflows.md`
- `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md`

### Decision group: TIDAS external LCA source preparation

- action: update-docs
- grouping basis: The merged governance PR remapped `tidas-tools/src/tidas_tools/import_lca/**` to `user-docs-tidas-package-workflow`, so EcoSpold1, EcoSpold2, and import_lca writer changes now require user-docs review against the TIDAS ZIP workflow pages.
- per-source evidence: source version code context from `tiangong-lca/tidas-tools#60` at merge commit `322458b2399c8c37c3cd706a470547bd395f2372` shows EcoSpold1 conversion stabilization; source version code context from `tiangong-lca/tidas-tools#62` at merge commit `c845188baa02852f1e3d0be28f495d1478cf142d` shows `tidas-import` support for external LCA source detection, `.zolca` rejection, machine-readable conversion reports, EcoSpold 1, EcoSpold 2, SimaPro CSV, openLCA JSON-LD, and openLCA process XLSX, plus validation of generated TIDAS packages.
- combined business impact: Web users still upload a TIDAS ZIP package, not raw EcoSpold or other source files. The docs should make the boundary explicit: convert external LCA formats with the tooling first, then upload the generated TIDAS ZIP through the web UI.
- target document structure reviewed: Reviewed `docs/user-guide/tidas-zip-workflows.md` and `i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md`; the relevant outline is import scope, import rules, import steps, outcomes, troubleshooting, export, task center, and UI-vs-API guidance.
- page outline: `TIDAS ZIP 导入、导出与任务中心 > 导入 TIDAS ZIP 数据包 > 适用场景`, `基本规则`, `导入步骤`, `可能出现的结果`, `如何排查失败`; English mirror `TIDAS ZIP Import, Export, and Task Center > Import TIDAS ZIP Package > Typical use cases`, `Rules`, `Import steps`, `Possible outcomes`, `How to troubleshoot`.
- new content type: user-facing format-boundary note with examples of external source formats.
- placement candidates: Import rules, troubleshooting, and UI-vs-API guidance.
- placement decision: update existing H2 content and add a new same-level heading under the import section.
- selected placement: Add a short H3 after the import rules and before import steps.
- target file: docs/user-guide/tidas-zip-workflows.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md
- heading path: TIDAS ZIP 导入、导出与任务中心 > 导入 TIDAS ZIP 数据包 > 外部 LCA 格式需先转换
- mirror placement: TIDAS ZIP Import, Export, and Task Center > Import TIDAS ZIP Package > Convert external LCA formats first
- insertion point: new same-level heading after import rules.
- placement rationale: The import rules section is where users decide what file can be uploaded. Stating that raw external LCA formats must be converted before web upload prevents users from treating EcoSpold or openLCA files as directly accepted web inputs.
- rejected placements: Troubleshooting would be too late because the user would already have selected the wrong file type; UI-vs-API is about interaction channel rather than source format preparation; key-functions docs only list the button and should not carry format conversion details.
- post-change placement check: Verify only the Chinese and English TIDAS ZIP workflow pages change, verify both edits live under the import section, and verify the mirror text says the same thing as the Chinese text.

### Decision group: latest-version data list replay

- action: noop
- grouping basis: The merged governance PR remapped latest-version database migrations and general data/version helpers to `user-docs-data-catalog-reference`.
- per-source evidence: source version code context from `tiangong-lca/database-engine#54` at merge commit `7d321ad7484f4992bcc19c585ba34e46106a75dc` shows latest-version list/search RPCs for source, contact, unit group, flow property, flow, process, and lifecycle model datasets; source version code context from `linancn/tiangong-lca-next#427` at merge commit `7c79ef9f73e508f6e092ed88c37558cc4813d9e3` shows general data/version helpers and all-version drawer behavior.
- combined business impact: The user-visible behavior is the same latest-version and all-versions behavior already handled by mapped docs PR `linancn/tiangong-lca-next-docs#49`.
- reason: No separate replay edit is made to `docs/user-guide/data-use.md`, `i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md`, `docs/user-guide/data.md`, `i18n/en/docusaurus-plugin-content-docs/current/user-guide/data.md`, `docs/user-guide/create-my-data.md`, or `i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md` because Draft PR #49 already carries the combined data-list doc update.

### Decision group: national carbon dashboard replay

- action: noop
- grouping basis: The merged governance PR added `user-docs-national-carbon-dashboard` for `tiangong-lca-next/src/pages/NationalCarbonDashboard/**`.
- per-source evidence: source version code context from `linancn/tiangong-lca-next#425` at merge commit `f35b9db02b289619415691d49a546d6dc4b0190a` shows `/dashboard/national-carbon`, dashboard schema, mock snapshot, and page screens.
- combined business impact: The route is still `menu: false` and `layout: false`, so the evidence does not establish a normal public navigation entry that should be added to key-functions docs.
- reason: No replay edit is made to `docs/user-guide/key-functions-introduction.md` or `i18n/en/docusaurus-plugin-content-docs/current/user-guide/key-functions-introduction.md`; documenting the hidden dashboard as a common key function would overstate the public UI contract.

### Decision group: calculator and LCIA replay surfaces

- action: noop
- grouping basis: Original mapped calculator paths remain reviewed under `user-docs-lcia-results` and `user-docs-process-workspace`.
- per-source evidence: source version code context from `linancn/tiangong-lca-calculator#48` at merge commit `811eccc19eb3705ac14b9413da5c0b85a281351e` shows internal worker transaction-pooler compatibility changes.
- combined business impact: LCIA result guidance, process-analysis guidance, and system model FAQ behavior are unchanged by internal database pooler compatibility work.
- reason: No replay edit is made to `docs/user-guide/lcia.md`, `i18n/en/docusaurus-plugin-content-docs/current/user-guide/lcia.md`, `docs/user-guide/process-analysis.md`, `i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md`, `docs/faq/system-models.md`, or `i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md`.

<!-- docs-impact-pre-change-summary:end -->
