### PR TITLE
docs-impact: add CLI integration guide

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "fe1c1d65a7827afd0dfed223a13dd50aa0aa60b3"
+lastReviewedAt: "2026-06-23"
+lastReviewedCommit: "5282d078121bceb14a1278c104ceac654ddd3ed0"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: fe1c1d65a7827afd0dfed223a13dd50aa0aa60b3
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 5282d078121bceb14a1278c104ceac654ddd3ed0
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: fe1c1d65a7827afd0dfed223a13dd50aa0aa60b3
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 5282d078121bceb14a1278c104ceac654ddd3ed0
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -35,8 +35,6 @@ related:
   - docs/agents/repo-validation.md
 ---
 
-# next-docs Repo Architecture
-
 `tiangong-lca-next-docs` owns the public TianGong LCA documentation site built with Docusaurus.
 
 ## Owned Surfaces

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -35,8 +35,6 @@ related:
   - docs/agents/repo-architecture.md
 ---
 
-# next-docs Validation Guide
-
 The canonical local commands are:
 
 ```bash

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: fe1c1d65a7827afd0dfed223a13dd50aa0aa60b3
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 5282d078121bceb14a1278c104ceac654ddd3ed0
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/integration/cli.md
+++ b/docs/integration/cli.md
@@ -1,0 +1,141 @@
+# 天工 LCA CLI
+
+天工 LCA CLI 是面向自动化、批量处理和本地数据治理场景的命令行工具。它通过公开 npm 包 `@tiangong-lca/cli` 提供统一入口 `tiangong-lca`，适合在终端、脚本或代理工作流中调用天工 LCA 的搜索、读取、校验、生成、审核和发布准备能力。
+
+## 适用场景
+
+- 需要在脚本中搜索或读取 flow、process、lifecyclemodel 数据。
+- 需要在生成新 flow 或 process 前运行 identity preflight，避免重复创建或低置信度写入。
+- 需要在本地校验 TIDAS rows、重写引用、补齐必填字段或生成稳定的报告工件。
+- 需要把 process、flow 或 lifecyclemodel 的本地构建、审核和发布准备步骤串成可复现流程。
+
+## 运行方式
+
+一次性运行最新发布版本：
+
+```bash
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca --help
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca doctor
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca flow --help
+```
+
+也可以全局安装后使用：
+
+```bash
+npm install --global @tiangong-lca/cli
+tiangong-lca --help
+tiangong-lca doctor
+```
+
+CLI 当前运行基线是 Node.js 24。若在自动化环境中固定版本，请先确认运行机使用 Node.js `24.x`。
+
+## 环境变量
+
+纯本地命令通常不需要远程凭证。访问天工 LCA 远程 API、Edge Functions 或需要远程候选集的命令时，配置以下变量：
+
+```bash
+TIANGONG_LCA_API_BASE_URL=
+TIANGONG_LCA_API_KEY=
+TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY=
+TIANGONG_LCA_REGION=us-east-1
+```
+
+`TIANGONG_LCA_API_KEY` 是账户页生成的天工 LCA 用户 API Key，不是 Supabase project key。CLI 会使用它换取用户 session，再用解析出的 access token 访问远程服务。
+
+可选的本地 session 控制变量：
+
+```bash
+TIANGONG_LCA_SESSION_FILE=
+TIANGONG_LCA_DISABLE_SESSION_CACHE=false
+TIANGONG_LCA_FORCE_REAUTH=false
+```
+
+## 常用命令
+
+### 环境诊断
+
+```bash
+tiangong-lca doctor
+tiangong-lca doctor --json
+```
+
+`doctor` 会检查 CLI 能读取到的环境变量，并用脱敏值展示当前配置状态。
+
+### 搜索与读取
+
+```bash
+tiangong-lca search flow --input ./search-flow.request.json --json
+tiangong-lca search process --input ./search-process.request.json --json
+tiangong-lca search lifecyclemodel --input ./search-lifecyclemodel.request.json --json
+
+tiangong-lca flow get --id <flow-id> --version <version> --json
+tiangong-lca flow list --id <flow-id> --state-code 100 --limit 20 --json
+tiangong-lca process get --id <process-id> --version <version> --json
+tiangong-lca process list --state-code 100 --limit 20 --json
+```
+
+搜索和远程读取需要远程环境变量。读取类命令会按命令参数过滤目标数据集，并优先输出结构化 JSON，便于后续脚本继续处理。
+
+### 生成前预检
+
+```bash
+tiangong-lca process identity-preflight --input ./process-preflight.json --out-dir ./process-preflight --json
+tiangong-lca flow identity-preflight --input ./flow-preflight.json --out-dir ./flow-preflight --json
+```
+
+identity preflight 会比较目标对象与本地或远程候选数据，输出可复用的 `IdentityDecision`、候选证据和 blocker/manual-review 状态。需要远程候选时，可使用对应命令的 `--remote-candidates`、`--remote-query` 和 `--remote-limit` 参数。
+
+### Build-plan gate
+
+```bash
+tiangong-lca process build-plan validate --input ./process-build-plan.json --out-dir ./process-build-plan --json
+tiangong-lca process build-plan materialize --input ./process-build-plan.json --out-dir ./process-build-plan --json
+tiangong-lca flow build-plan validate --input ./flow-build-plan.json --out-dir ./flow-build-plan --json
+tiangong-lca flow build-plan materialize --input ./flow-build-plan.json --out-dir ./flow-build-plan --json
+```
+
+build-plan gate 用于在生成或发布交接前校验最小 authoring contract，并在可物化时写出标准 `GateReport` 和 deterministic TIDAS payload。
+
+### 数据校验与引用处理
+
+```bash
+tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir ./dataset-validate --json
+tiangong-lca dataset verify-remote --input ./rows.jsonl --out-dir ./dataset-remote-verify --json
+tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir ./dataset-rewrite --json
+tiangong-lca dataset bilingual extract --input ./rows/processes.jsonl --type process --out-dir ./translation --json
+tiangong-lca dataset bilingual apply --input ./rows/processes.jsonl --translations ./translation/trans-reviewed.jsonl --out ./rows/processes.translated.jsonl --json
+tiangong-lca dataset bilingual validate --input ./rows/processes.translated.jsonl --type process --out-dir ./translation-validate --json
+```
+
+这些命令优先写出本地报告、JSONL 结果和证据工件。涉及远程写入的命令只有在显式提供 `--commit` 或命令语义要求远程验证时才会访问远程服务。
+
+### Process、flow 与 lifecyclemodel 工作流
+
+```bash
+tiangong-lca process auto-build --input ./examples/process-auto-build.request.json --out-dir ./process-run --json
+tiangong-lca process resume-build --run-dir ./process-run --json
+tiangong-lca process publish-build --run-dir ./process-run --json
+
+tiangong-lca flow fetch-rows --refs-file ./flow-refs.json --out-dir ./flow-fetch --json
+tiangong-lca review flow --rows-file ./flow-fetch/review-input-rows.jsonl --out-dir ./flow-review
+tiangong-lca flow materialize-decisions --decision-file ./approved-decisions.json --flow-rows-file ./flow-fetch/review-input-rows.jsonl --out-dir ./flow-decisions
+
+tiangong-lca lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir ./lifecyclemodel-run --json
+tiangong-lca lifecyclemodel validate-build --run-dir ./lifecyclemodel-run --json
+tiangong-lca lifecyclemodel publish-build --run-dir ./lifecyclemodel-run --json
+```
+
+这些命令用于把本地构建、审核、校验和发布准备拆成可重复运行的步骤。发布准备类命令通常先生成 bundle、request、intent 或 report，最终是否写入远程由对应命令的 `--dry-run` / `--commit` 边界决定。
+
+## 输出与安全边界
+
+- 优先使用 `--json` 获得稳定结构化输出，方便在 CI 或代理流程中解析。
+- 设置 `--out-dir` 时，命令会把报告、成功/失败列表和中间工件写入该目录。
+- 不要把 `TIANGONG_LCA_API_KEY`、session 文件或生成的凭证提交到仓库。
+- 在执行带 `--commit` 的命令前，先用 dry-run 或本地报告确认输入范围、目标用户和将要写入的数据。
+
+## 后续步骤
+
+- 需要连接 MCP 工具时，继续阅读[本地 MCP](../MCP/lca_local.md)或[远程 MCP](../MCP/lca_remote.md)。
+- 需要了解 TIDAS ZIP 导入导出流程时，阅读[TIDAS ZIP 工作流](../user-guide/tidas-zip-workflows.md)。
+- 需要调用公开导入接口时，阅读[OpenAPI TIDAS 包导入](../openapi/tidas-package-import.md)。

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
@@ -1,0 +1,141 @@
+# TianGong LCA CLI
+
+The TianGong LCA CLI is a command-line tool for automation, batch operations, and local data governance. It is published as the npm package `@tiangong-lca/cli` and exposes the unified entrypoint `tiangong-lca` for search, read, validation, generation, review, and publish-preparation workflows.
+
+## When to Use It
+
+- Search or read flow, process, and lifecyclemodel data from scripts.
+- Run identity preflight before generating new flows or processes so duplicate creation and low-confidence writes can be blocked early.
+- Validate local TIDAS rows, rewrite references, complete required fields, or generate stable report artifacts.
+- Chain process, flow, or lifecyclemodel build, review, and publish-preparation steps into a reproducible workflow.
+
+## Run the CLI
+
+Run the latest published version without installing it globally:
+
+```bash
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca --help
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca doctor
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca flow --help
+```
+
+Or install it globally:
+
+```bash
+npm install --global @tiangong-lca/cli
+tiangong-lca --help
+tiangong-lca doctor
+```
+
+The current runtime baseline is Node.js 24. If you run the CLI in automation, make sure the runner uses Node.js `24.x`.
+
+## Environment Variables
+
+Purely local commands usually do not need remote credentials. Configure these variables when a command accesses the TianGong LCA remote API, Edge Functions, or remote candidate search:
+
+```bash
+TIANGONG_LCA_API_BASE_URL=
+TIANGONG_LCA_API_KEY=
+TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY=
+TIANGONG_LCA_REGION=us-east-1
+```
+
+`TIANGONG_LCA_API_KEY` is the TianGong LCA user API key generated from the account page, not a Supabase project key. The CLI exchanges it for a user session and then uses the resolved access token for remote service calls.
+
+Optional local session controls:
+
+```bash
+TIANGONG_LCA_SESSION_FILE=
+TIANGONG_LCA_DISABLE_SESSION_CACHE=false
+TIANGONG_LCA_FORCE_REAUTH=false
+```
+
+## Common Commands
+
+### Environment Diagnostics
+
+```bash
+tiangong-lca doctor
+tiangong-lca doctor --json
+```
+
+`doctor` checks the environment visible to the CLI and prints the current configuration state with sensitive values masked.
+
+### Search and Read
+
+```bash
+tiangong-lca search flow --input ./search-flow.request.json --json
+tiangong-lca search process --input ./search-process.request.json --json
+tiangong-lca search lifecyclemodel --input ./search-lifecyclemodel.request.json --json
+
+tiangong-lca flow get --id <flow-id> --version <version> --json
+tiangong-lca flow list --id <flow-id> --state-code 100 --limit 20 --json
+tiangong-lca process get --id <process-id> --version <version> --json
+tiangong-lca process list --state-code 100 --limit 20 --json
+```
+
+Search and remote read commands require the remote environment variables. Read commands filter the target dataset by command arguments and prefer structured JSON output so downstream scripts can keep processing the result.
+
+### Preflight Before Generation
+
+```bash
+tiangong-lca process identity-preflight --input ./process-preflight.json --out-dir ./process-preflight --json
+tiangong-lca flow identity-preflight --input ./flow-preflight.json --out-dir ./flow-preflight --json
+```
+
+Identity preflight compares a target object with local or remote candidate data and emits a reusable `IdentityDecision`, candidate evidence, and blocker/manual-review status. Use the command-specific `--remote-candidates`, `--remote-query`, and `--remote-limit` flags when remote candidates are needed.
+
+### Build-Plan Gate
+
+```bash
+tiangong-lca process build-plan validate --input ./process-build-plan.json --out-dir ./process-build-plan --json
+tiangong-lca process build-plan materialize --input ./process-build-plan.json --out-dir ./process-build-plan --json
+tiangong-lca flow build-plan validate --input ./flow-build-plan.json --out-dir ./flow-build-plan --json
+tiangong-lca flow build-plan materialize --input ./flow-build-plan.json --out-dir ./flow-build-plan --json
+```
+
+Build-plan gates validate the minimum authoring contract before generation or publish handoff, and when materialization is possible they write a standard `GateReport` plus deterministic TIDAS payloads.
+
+### Data Validation and Reference Handling
+
+```bash
+tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir ./dataset-validate --json
+tiangong-lca dataset verify-remote --input ./rows.jsonl --out-dir ./dataset-remote-verify --json
+tiangong-lca dataset references rewrite --input ./rows.jsonl --from flow:<old-id>@<old-version> --to flow:<new-id>@<new-version> --out-dir ./dataset-rewrite --json
+tiangong-lca dataset bilingual extract --input ./rows/processes.jsonl --type process --out-dir ./translation --json
+tiangong-lca dataset bilingual apply --input ./rows/processes.jsonl --translations ./translation/trans-reviewed.jsonl --out ./rows/processes.translated.jsonl --json
+tiangong-lca dataset bilingual validate --input ./rows/processes.translated.jsonl --type process --out-dir ./translation-validate --json
+```
+
+These commands prioritize local reports, JSONL results, and evidence artifacts. Commands that can write remotely only access remote services when `--commit` is explicitly provided or when the command semantics require remote verification.
+
+### Process, Flow, and Lifecyclemodel Workflows
+
+```bash
+tiangong-lca process auto-build --input ./examples/process-auto-build.request.json --out-dir ./process-run --json
+tiangong-lca process resume-build --run-dir ./process-run --json
+tiangong-lca process publish-build --run-dir ./process-run --json
+
+tiangong-lca flow fetch-rows --refs-file ./flow-refs.json --out-dir ./flow-fetch --json
+tiangong-lca review flow --rows-file ./flow-fetch/review-input-rows.jsonl --out-dir ./flow-review
+tiangong-lca flow materialize-decisions --decision-file ./approved-decisions.json --flow-rows-file ./flow-fetch/review-input-rows.jsonl --out-dir ./flow-decisions
+
+tiangong-lca lifecyclemodel auto-build --input ./examples/lifecyclemodel-auto-build.request.json --out-dir ./lifecyclemodel-run --json
+tiangong-lca lifecyclemodel validate-build --run-dir ./lifecyclemodel-run --json
+tiangong-lca lifecyclemodel publish-build --run-dir ./lifecyclemodel-run --json
+```
+
+Use these commands to split local build, review, validation, and publish-preparation work into repeatable steps. Publish-preparation commands typically generate bundles, requests, intents, or reports first; remote writes remain controlled by each command's `--dry-run` / `--commit` boundary.
+
+## Outputs and Safety Boundaries
+
+- Prefer `--json` for stable structured output in CI or agent workflows.
+- Set `--out-dir` when you want reports, success/failure lists, and intermediate artifacts written to a predictable directory.
+- Do not commit `TIANGONG_LCA_API_KEY`, session files, or generated credentials to a repository.
+- Before running a command with `--commit`, use dry-run mode or local reports to confirm the input scope, target user, and data that will be written.
+
+## Next Steps
+
+- To connect MCP tooling, continue with [Local MCP](../MCP/lca_local.md) or [Remote MCP](../MCP/lca_remote.md).
+- To work with TIDAS ZIP import and export flows, read [TIDAS ZIP Workflows](../user-guide/tidas-zip-workflows.md).
+- To call the public import API, read [OpenAPI TIDAS Package Import](../openapi/tidas-package-import.md).

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -101,6 +101,7 @@ const sidebars: SidebarsConfig = {
         'MCP/lca_local',
         'MCP/lca_remote',
         'MCP/KB_remote',
+        'integration/cli',
         {
           type: 'link',
           label: 'MCP AI 服务',


### PR DESCRIPTION
## 摘要

- 新增公开文档页 `docs/integration/cli.md`，介绍 `@tiangong-lca/cli` 的安装、环境变量、常用命令与安全边界。
- 新增英文镜像 `i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md`。
- 在 `sidebars.ts` 的“集成与扩展”分类中加入 `integration/cli`，保证新页面可发现。
- 记录本次 public docs 与 site structure 变更所需的 docpact review evidence，并修复已触达 agent docs 的重复 H1 lint 问题。

Refs tiangong-lca/workspace#291

## 验证

- `validate-pre-change-decision.rb --stage mapped`: pass
- `validate-doc-placement.rb` pre-commit public-doc diff: pass
- `validate-doc-placement.rb` `origin/main...HEAD` public-doc diff: pass
- `npm run lint`: pass
- `npm run typecheck`: pass（在本地 `npm install --no-package-lock` 后运行）
- `scripts/docpact validate-config --root . --strict`: pass
- `scripts/docpact lint --root . --base origin/main --head HEAD --mode enforce`: pass
- `npm run docs:llms`: script absent
- `npm run docs:llms:check`: script absent
- `npm run docs:publication-scope:check`: script absent
- `npm run build`: failed，保持 Draft。原因是该 worktree 没有 `package-lock.json`，本地 `npm install --no-package-lock` 解析出的依赖在 Docusaurus build 阶段触发 Webpack `ProgressPlugin` options schema 校验错误（unknown properties `name`、`color`、`reporters`、`reporter`）。该失败发生在站点编译初始化阶段，不指向本 PR 新增 Markdown 或 sidebar 引用。

## 风险与后续

- PR 使用 fork 分支 `ForeverYoung5:docs/impact-issue-291`，目标为 canonical repo `linancn/tiangong-lca-next-docs:main`。
- 由于 `npm run build` 存在依赖解析/构建环境 blocker，本 PR 保持 Draft，等待维护者确认依赖锁定或 Docusaurus/Webpack 兼容处理。

## Pre-change decision summary

<!-- docs-impact-pre-change-summary:start -->
- stage: mapped
- issue: tiangong-lca/workspace#291
- target root: /Users/foreveryoung/tiangong/automation-worktree1/docs-impact/issue-291/mapped/next-docs-edit
- metadata file: /tmp/docs-impact-metadata.json
- source worktrees file: /tmp/docs-impact-sources.json
- grouping basis: 按 metadata.matches 的 requiredDocIds 聚合；本次执行先处理唯一缺失的公开页面组 d1/d2，同时在本摘要中覆盖所有 mapped required docs，避免遗漏扫描输入。
- scanner input: window 2026-05-23T16:00:00Z..2026-05-25T16:00:00Z；stage mapped；CLI 组 rule id 为 user-docs-cli-public-usage；source PR 为 tiangong-lca/tiangong-cli#107 与 tiangong-lca/tiangong-cli#110。
- required docs covered: tiangong-lca-next-docs/docs/integration/cli.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md; tiangong-lca-next-docs/docs/user-guide/tidas-zip-workflows.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md; tiangong-lca-next-docs/docs/user-guide/data.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/data.md; tiangong-lca-next-docs/docs/user-guide/data-use.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md; tiangong-lca-next-docs/docs/user-guide/lcia.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/lcia.md; tiangong-lca-next-docs/docs/faq/system-models.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md; tiangong-lca-next-docs/docs/user-guide/process-analysis.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md; tiangong-lca-next-docs/docs/user-guide/key-functions-introduction.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/key-functions-introduction.md; tiangong-lca-next-docs/docs/MCP/lca_local.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_local.md; tiangong-lca-next-docs/docs/MCP/lca_remote.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_remote.md; tiangong-lca-next-docs/docs/user-guide/create-my-data.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md; tiangong-lca-next-docs/docs/user-guide/data-review.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md; tiangong-lca-next-docs/docs/user-guide/permissions-and-data-scopes.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md; tiangong-lca-next-docs/docs/openapi/tidas-package-import.md; tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md。
- overall selected action: create-docs
- validation plan: 先运行 validate-pre-change-decision.rb；编辑后只暂存 docs/integration/cli.md、英文镜像与 sidebars.ts；生成 public-doc-only cached diff 运行 validate-doc-placement.rb；提交后用 origin/main...HEAD 再跑 placement；随后运行 npm run lint、npm run typecheck、npm run build、scripts/docpact validate-config --root . --strict、scripts/docpact lint --root . --base origin/main --head HEAD --mode enforce；若新增页面触发发布索引脚本且 package.json 存在 docs:llms、docs:llms:check、docs:publication-scope:check，也运行并记录。

### Decision group: cli-integration-page-d1-d2

- grouping basis: requiredDocIds d1/d2 同属缺失的 CLI integration 页面；metadata.requiredDocsMissing 指向中文页 tiangong-lca-next-docs/docs/integration/cli.md 与英文镜像 tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md。
- scanner input: rule id user-docs-cli-public-usage；matched files 包括 tiangong-lca-cli/src/cli.ts、src/lib/dataset-bilingual.ts、src/lib/dataset-validate.ts、src/lib/process-flow-build-plan.ts、src/lib/process-payload-validation.ts、src/lib/process-publish-build.ts、src/lib/process-refresh-references.ts、src/lib/process-required-fields.ts、src/lib/process-save-draft-run.ts、src/lib/publish.ts，以及 #110 新增的 dataset remote verify/refresh、flow publish、review、process auto/dedup 等 CLI public command paths。
- per-source evidence: source version #107 c7e5ff64a0696e5965c8c03cf86d5b5bccc3beb9 from /Users/foreveryoung/tiangong/automation-worktree1/docs-impact/issue-291/source-evidence/tiangong-lca-cli/pr-107；source version #110 906fed4c1e8b2d2c0df30dfd854b3168b8dabdd5 from /Users/foreveryoung/tiangong/automation-worktree1/docs-impact/issue-291/source-evidence/tiangong-lca-cli/pr-110；code context checked: package.json bin exposes @tiangong-lca/cli and tiangong-lca, src/cli.ts renderMainHelp lists implemented command families and examples, src/lib/env.ts defines TIANGONG_LCA_API_BASE_URL / TIANGONG_LCA_API_KEY / TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY / TIANGONG_LCA_REGION / session controls, README.md documents npm exec, global install, env, search/read/identity/build-plan/review examples.
- UI-string evidence: code path checked 为 tiangong-lca-cli/src/cli.ts renderMainHelp/render*Help 与 README.md；referenced i18n ids: none；zh-CN resolved strings: not_applicable，因为该路径不是 React UI 且没有 locale 文件；en-US resolved strings: hard-coded CLI/help terms `TianGong LCA CLI`, `tiangong-lca`, `doctor`, `search`, `process`, `dataset`, `flow`, `lifecyclemodel`, `review`, `publish`, `validation`, `admin`；missing/fallback strings: none；canonical terminology decision: 中文公开文档使用“天工 LCA CLI”“命令行工具”，命令、包名、环境变量、输出文件名保持 English/code form；英文镜像使用 “TianGong LCA CLI”。
- combined business impact: CLI 已成为公开 npm 包和统一执行入口，用户可以通过 npm 一次性运行或全局安装后执行搜索、读取、身份预检、build-plan gate、数据校验/引用改写、生命周期模型构建、review、publish 等任务；next-docs 当前没有对应入口页，会让集成读者只能从内部 README 或源码推断用法。
- impact trace: merged CLI source PR -> package.json/bin 与 src/cli.ts/README public invocation contract -> 外部用户需要安装、配置 env、选择命令族 -> next-docs 集成与扩展栏目缺少 public guide -> 创建 integration/cli.md 与英文镜像并加入 sidebar。
- user-visible impact: yes。
- target document structure reviewed: docs/integration/cli.md 不存在；i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md 不存在；sidebars.ts 的“集成与扩展”分类存在并已包含 MCP/lca_local、MCP/lca_remote、MCP/KB_remote 与外部 MCP AI 服务链接。
- document purpose reviewed: docs/integration/** 适合面向集成者的任务型技术指南；该页面应帮助用户完成 CLI 安装、配置和选择常用命令，不写内部实现历史或维护者流程。
- page structure map: 新页面规划为 H1 天工 LCA CLI / TianGong LCA CLI；H2 适用场景；H2 运行方式；H2 环境变量；H2 常用命令；H2 输出与安全边界；H2 后续步骤。
- relevant existing content reviewed: docs/MCP/lca_local.md 与 docs/MCP/lca_remote.md 都位于“集成与扩展”，用步骤、命令块和配置说明介绍外部工具连接；没有 CLI 页面或与 @tiangong-lca/cli 重复的公开说明。
- affected existing claims: 当前 sidebar “集成与扩展”只呈现 MCP 相关入口，未声称 CLI 不存在；无需替换旧声明。
- existing-claim reconciliation: create-page；没有现有 CLI 页可更新，新增页面比把 CLI 内容塞进 MCP 页面更符合读者任务边界。
- edit operation: create-page
- why not only update existing content: CLI 是独立 npm package 与命令行执行面，不是 MCP 本地/远程连接步骤；更新 MCP 页面会混淆工具边界，也无法给用户可发现的 CLI 入口。
- selected edit target: 新增中文 docs/integration/cli.md、英文镜像 i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md，并在 sidebars.ts 的“集成与扩展” items 中加入 integration/cli。
- target file: docs/integration/cli.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
- new content type: public task-oriented integration guide，包含安装/运行命令、env contract、常用命令族、artifact/output 注意事项和读者下一步。
- placement candidates: 1) 在“集成与扩展”新增独立 integration/cli 页面；2) 追加到 docs/MCP/lca_local.md；3) 追加到 docs/MCP/lca_remote.md；4) 放入 dev/dev-env.md。
- placement decision: new page
- selected placement: # 天工 LCA CLI
- heading path: 天工 LCA CLI
- insertion point: new page under docs/integration/cli.md and new sidebar item integration/cli after MCP/KB_remote in “集成与扩展”。
- reader block boundary: 新页面从 H1 开始，不插入既有 reader block；sidebar item 插入在同类集成项列表中，位于 MCP/KB_remote 后、外部 MCP AI 服务链接前。
- placement rationale: CLI 是集成者面向本地/远程 TianGong 能力的命令行入口，和 MCP 同属“集成与扩展”；独立页面能承载 env 与命令族说明，并避免污染用户指南或部署开发页。
- rejected placements: MCP local/remote 页面只讲 MCP server 调用；dev/dev-env 面向文档/开发环境；user-guide 页面面向平台 UI，不适合 CLI package installation；OpenAPI 页面面向 HTTP contract，不适合命令行使用。
- mirror semantic equivalence: 英文镜像与中文页保持相同结构和事实；命令、环境变量、包名、输出文件名完全一致；自然语言翻译为英文。
- mirror placement: TianGong LCA CLI
- navigation decision: 新建公开 docs page 必须可发现；更新 sidebars.ts 的 “集成与扩展” category，在 MCP/KB_remote 后加入 integration/cli；英文镜像由同一 doc id 对应，无单独 sidebar 入口。
- selected navigation target: sidebars.ts tutorialSidebar > 集成与扩展 > items: add `integration/cli`.
- validation plan: pre-change pass 后编辑页面和 sidebar；precommit placement 只验证两个 markdown 文件；sidebars.ts 通过 npm build/typecheck/lint 验证；新增页面后检查 package.json 是否存在 docs:llms、docs:llms:check、docs:publication-scope:check 并按脚本存在性运行/记录。
- post-change placement check: precommit diff 和 after-commit diff 均应显示 docs/integration/cli.md 与英文镜像新增完整页面；placement helper 应将两者识别为 new page under declared H1；sidebars.ts 通过 build 验证导航引用。
- selected action: create-docs
- reason: metadata 明确报告 CLI public usage mapped docs 缺失，source evidence 证明 CLI 已有公开包、命令和 env contract；创建页面和导航比 reviewed-no-change 更符合 public docs discoverability。
- action: create-docs
<!-- docs-impact-pre-change-summary:end -->

<!-- docs-impact-local-apply-mapped:v1
{
  "docsImpactIssue": "tiangong-lca/workspace#291",
  "sourcePullRequests": [
    "tiangong-lca/tiangong-cli#107",
    "tiangong-lca/tiangong-cli#110"
  ],
  "ruleIds": [
    "user-docs-cli-public-usage"
  ],
  "localWorker": true
}
-->
