### PR TITLE
fix: regenerate llms before docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ npm run build
 npm run serve
 ```
 
+`npm run build` runs `npm run docs:llms` through `prebuild` first, so hosted platforms that only
+invoke the standard build command still publish `llms.txt` with the current build commit.
+
 ## Recommended verification
 
 For public-doc changes, run at least:

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -118,6 +118,9 @@ npm run typecheck
 npm run build
 ```
 
+`npm run build` 会先通过 `prebuild` 自动执行 `npm run docs:llms`，确保托管平台只调用
+标准构建命令时，发布产物中的 `llms.txt` 也会写入当前构建 commit。
+
 ### 本地预览构建产物
 
 ```bash

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
@@ -118,6 +118,9 @@ npm run typecheck
 npm run build
 ```
 
+`npm run build` runs `npm run docs:llms` through `prebuild` first, so hosted platforms that only
+invoke the standard build command still publish an `llms.txt` file with the current build commit.
+
 ### Serve the built site locally
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "prebuild": "npm run docs:llms",
     "build": "docusaurus build",
     "docs:llms": "node scripts/generate-llms-txt.mjs",
     "docs:llms:check": "node scripts/generate-llms-txt.mjs --check",


### PR DESCRIPTION
## Summary
- Add an npm `prebuild` hook so every `npm run build` regenerates `static/llms.txt` before Docusaurus copies static assets.
- Document that hosted platforms using the standard build command will publish an `llms.txt` file with the current build commit.

## Why
- EdgeOne Pages currently serves `docs.tiangong.earth`; it can run the standard build command without the GitHub Actions `docs:llms` pre-step.
- Regenerating during `npm run build` keeps `/llms.txt` aligned with the actual production build commit.

## Validation
- npm run docs:llms:check
- npm run docs:publication-scope:check
- npm run lint
- npm run typecheck
- GITHUB_SHA="$(git rev-parse HEAD)" npm run build
- npm run docs:publication-scope:check
