### PR TITLE
docs: 补充 TIDAS 导入字段兼容性说明

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "fe1c1d65a7827afd0dfed223a13dd50aa0aa60b3"
+lastReviewedAt: "2026-06-25"
+lastReviewedCommit: "96bac00b9b5db325d635e353315918b5148ef61d"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: fe1c1d65a7827afd0dfed223a13dd50aa0aa60b3
+lastReviewedAt: 2026-06-25
+lastReviewedCommit: 96bac00b9b5db325d635e353315918b5148ef61d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ checkPaths:
   - scripts/publication-policy.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20f0a67cd7ec473f1d37fff4df534ea7fcb44349
+lastReviewedAt: 2026-06-25
+lastReviewedCommit: 96bac00b9b5db325d635e353315918b5148ef61d
 related:
   - AGENTS.md
   - docs/agents/repo-validation.md

--- a/TODO.docs-system-gaps.md
+++ b/TODO.docs-system-gaps.md
@@ -20,8 +20,8 @@ checkPaths:
   - scripts/check-publication-scope.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20f0a67cd7ec473f1d37fff4df534ea7fcb44349
+lastReviewedAt: 2026-06-25
+lastReviewedCommit: 844f1dba3339131593d1995569acd8eb16a8022a
 related:
   - AGENTS.md
   - README.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: fe1c1d65a7827afd0dfed223a13dd50aa0aa60b3
+lastReviewedAt: 2026-06-25
+lastReviewedCommit: 96bac00b9b5db325d635e353315918b5148ef61d
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: fe1c1d65a7827afd0dfed223a13dd50aa0aa60b3
+lastReviewedAt: 2026-06-25
+lastReviewedCommit: 96bac00b9b5db325d635e353315918b5148ef61d
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -20,8 +20,8 @@ checkPaths:
   - scripts/check-publication-scope.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20f0a67cd7ec473f1d37fff4df534ea7fcb44349
+lastReviewedAt: 2026-06-25
+lastReviewedCommit: 96bac00b9b5db325d635e353315918b5148ef61d
 related:
   - i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
   - docs/agents/repo-validation.md

--- a/docs/openapi/tidas-package-import.md
+++ b/docs/openapi/tidas-package-import.md
@@ -269,6 +269,19 @@ curl -i --location --request GET "${BASE_URL}/tidas_package_jobs/<job-id>" \
 - 使用 `summary.error_count`、`summary.warning_count`、`summary.validation_issue_count`
   做顶部汇总
 
+### 流程数据集字段兼容性
+
+导入流程会按照当前 TIDAS schema 校验 `processes/*.json`。准备流程数据集时，特别注意
+`processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness` 下的
+`annualSupplyOrProductionVolume`：
+
+- 该字段现在是必填项
+- 值应按 TIDAS `Real` 类型提供，也就是可解析为数字的字符串，例如 `"123.45"` 或 `"1.2E3"`
+- 不要再把该字段写成 `StringMultiLang` 多语言文本对象
+
+如果仍使用旧格式，导入报告会返回 `schema_error`，并在 `file_path`、`location` 和 `message`
+中指出对应的流程文件与字段位置。
+
 ## 常见注意事项
 
 - 导入校验不会在浏览器本地同步完成，而是在异步 worker 中执行

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
@@ -20,8 +20,8 @@ checkPaths:
   - scripts/check-publication-scope.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20f0a67cd7ec473f1d37fff4df534ea7fcb44349
+lastReviewedAt: 2026-06-25
+lastReviewedCommit: 96bac00b9b5db325d635e353315918b5148ef61d
 related:
   - docs/dev/dev-env.md
   - docs/agents/repo-validation.md

--- a/i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md
@@ -285,6 +285,22 @@ Client recommendations:
 - Use `summary.error_count`, `summary.warning_count`, and
   `summary.validation_issue_count` for top-level summaries
 
+### Process Dataset Field Compatibility
+
+The import worker validates `processes/*.json` against the current TIDAS schema.
+When preparing process datasets, pay special attention to
+`annualSupplyOrProductionVolume` under
+`processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness`:
+
+- The field is now required
+- The value should use the TIDAS `Real` type, meaning a numeric string such as
+  `"123.45"` or `"1.2E3"`
+- Do not send this field as an old `StringMultiLang` multilingual text object
+
+Packages that still use the old shape fail with `schema_error`; the import
+report points to the process file and field through `file_path`, `location`, and
+`message`.
+
 ## Implementation Notes
 
 - Package validation is not completed synchronously in the browser; it runs in

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -4,7 +4,7 @@ Public documentation index for TianGong LCA users, integrators, and AI retrieval
 
 Source site: https://docs.tiangong.earth
 Source repository: https://github.com/linancn/tiangong-lca-next-docs
-Source commit: 171e605ecc57ad8deb7d56a567fcee63f036052b
+Source commit: a4ff5d6a8239360d2ef7eb8cae9657bfd078a98d
 Publication scope: public Docusaurus docs only. Internal agent, plan, incident, TODO, and governance execution records are excluded.
 
 ## English (en)


### PR DESCRIPTION
## 摘要

- 在 TIDAS 数据包导入 API 文档中补充流程数据集字段兼容性说明。
- 明确 `annualSupplyOrProductionVolume` 当前为必填的 TIDAS `Real` 数字字符串，不再是 `StringMultiLang` 多语言文本对象。
- 同步更新英文镜像，并纳入 `static/llms.txt` 生成结果与 docpact review evidence。

Refs tiangong-lca/workspace#311

## 验证

- `validate-pre-change-decision.rb --stage mapped`：pass
- `validate-doc-placement.rb` pre-commit public-doc diff：pass
- `validate-doc-placement.rb` post-commit public-doc diff：pass
- `npm run docs:llms`：pass，生成 `static/llms.txt`
- `npm run docs:llms:check`：pass
- `npm run docs:publication-scope:check`：pass
- `npm run lint`：pass
- `npm run typecheck`：pass
- `npm run build`：pass
- `scripts/docpact validate-config --root <next-docs> --strict`：pass
- `scripts/docpact lint --root <next-docs> --base origin/main --head HEAD --mode enforce`：pass

依赖说明：首次 `typecheck` 因隔离 worktree 缺少本地 `tsc` 失败；`npm ci` 也因仓库无 lockfile 不适用。已使用 `npm install --no-package-lock` 安装本地依赖后重跑并通过 `typecheck` 与 `build`，未提交依赖文件。

## 风险与后续

- 这是文档和 llms 索引更新，不改产品运行代码。
- 合并后仍需要通过 workspace submodule pointer 集成发布。

## Pre-change decision summary

<!-- docs-impact-pre-change-summary:start -->
## Coverage group plan

| groupId | groupName | targetDocs | sourcePullRequests | groupIntent |
|---|---|---|---|---|
| tidas-ui-validation-overview | TIDAS ZIP UI validation overview | `docs/user-guide/tidas-zip-workflows.md`; `i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md` | `tiangong-lca/tidas-tools#51` | Review whether the process schema change needs user workflow copy on the web UI page. |
| tidas-import-schema-contract | TIDAS process supply volume import contract | `docs/openapi/tidas-package-import.md`; `i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md` | `tiangong-lca/tidas-tools#51`; `tiangong-lca/tidas-sdk#62` | Document the changed machine-readable import validation contract for TIDAS process datasets. |

## Coverage ledger

| groupId | groupName | requiredDoc | ruleId | sourcePullRequest | terminal | reason |
|---|---|---|---|---|---|---|
| tidas-ui-validation-overview | TIDAS ZIP UI validation overview | `tiangong-lca-next-docs/docs/user-guide/tidas-zip-workflows.md` | `user-docs-tidas-package-workflow` | `tiangong-lca/tidas-tools#51` | reviewed-no-change | The UI workflow page already explains that package structure and required fields are validated and that failures are returned through modal/report artifacts; naming one low-level schema field there would duplicate API contract detail. |
| tidas-ui-validation-overview | TIDAS ZIP UI validation overview | `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md` | `user-docs-tidas-package-workflow` | `tiangong-lca/tidas-tools#51` | reviewed-no-change | English mirror already carries the same generic validation guidance; no UI label, step, or task-center behavior changed. |
| tidas-import-schema-contract | TIDAS process supply volume import contract | `tiangong-lca-next-docs/docs/openapi/tidas-package-import.md` | `user-docs-openapi-tidas-package-import` | `tiangong-lca/tidas-tools#51` | update-docs | Source schema changed `annualSupplyOrProductionVolume` from localized string to required numeric `Real`; API users need this validation requirement when preparing import packages. |
| tidas-import-schema-contract | TIDAS process supply volume import contract | `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md` | `user-docs-openapi-tidas-package-import` | `tiangong-lca/tidas-tools#51` | update-docs | English API mirror must reflect the same source schema requirement. |
| tidas-import-schema-contract | TIDAS process supply volume import contract | `tiangong-lca-next-docs/docs/openapi/tidas-package-import.md` | `user-docs-openapi-tidas-package-import` | `tiangong-lca/tidas-sdk#62` | update-docs | Generated TypeScript/Python SDK artifacts now expose `annualSupplyOrProductionVolume` as required numeric `Real`, confirming the public API/schema contract. |
| tidas-import-schema-contract | TIDAS process supply volume import contract | `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md` | `user-docs-openapi-tidas-package-import` | `tiangong-lca/tidas-sdk#62` | update-docs | English API mirror must reflect the SDK-visible required numeric contract. |

### Decision group: tidas-ui-validation-overview - TIDAS ZIP UI validation overview

- groupId: tidas-ui-validation-overview
- groupName: TIDAS ZIP UI validation overview
- grouping basis: same user workflow page, same source schema change, and same Chinese/English mirror ownership
- covered ledger keys:
  - `tiangong-lca-next-docs/docs/user-guide/tidas-zip-workflows.md | user-docs-tidas-package-workflow | tiangong-lca/tidas-tools#51`
  - `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md | user-docs-tidas-package-workflow | tiangong-lca/tidas-tools#51`
- scanner input: rule `user-docs-tidas-package-workflow`; required docs `docs/user-guide/tidas-zip-workflows.md` and English mirror; matched file `tidas-tools/src/tidas_tools/tidas/schemas/tidas_processes.json`
- per-source evidence: `tiangong-lca/tidas-tools#51`; source version `mergeCommit` `1d8e5273dd280807de269d83ac7588926b4ea709`; source worktree `/Users/foreveryoung/tiangong/automation-worktree1/docs-impact/issue-311/source-evidence/tidas-tools/pr-51`; checked code context `src/tidas_tools/tidas/schemas/tidas_processes.json` and `tests/test_validate.py`.
- combined business impact: TIDAS process dataset imports now require `processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume`, and the field is numeric `Real` rather than localized text.
- user-visible impact: no
- target: next-docs page review only
- target file: `docs/user-guide/tidas-zip-workflows.md`
- mirror file: `i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md`
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: page explains top-bar TIDAS ZIP import/export UI steps, task-center behavior, outcomes, and troubleshooting for web users.
- page structure map: H1 TIDAS ZIP import/export/task center; H2 entry location; H2 import package with use cases, rules, steps, outcomes, troubleshooting; H2 export package; H2 task center; H2 when to use UI vs API.
- relevant existing content reviewed: `导入 TIDAS ZIP 数据包` / `Import TIDAS ZIP Package` rules and outcome/troubleshooting sections mention structure validation, required-field validation, downloadable JSON reports, and API handoff.
- affected existing claims: correct
- existing-claim reconciliation: add only because no existing claim is needed is not applicable; existing generic validation claim remains accurate.
- edit operation: no public docs edit
- why not only update existing content: not applicable
- selected edit target: not applicable
- new content type: not applicable
- placement candidates: import rules, possible outcomes, troubleshooting, and UI/API comparison were reviewed and rejected for field-level schema detail.
- placement decision: not applicable
- selected placement: not applicable
- heading path: none
- insertion point: not applicable
- mirror placement: not applicable
- reader block boundary: no title or content insertion; existing import workflow reader blocks stay intact.
- placement rationale: field-level `Real` and required-property detail is an API/schema contract, not a UI workflow step or label.
- rejected placements: `导入步骤` / `Import steps` would imply a changed UI action; `可能出现的结果` / `Possible outcomes` already covers validation generically; `如何排查失败` / `How to troubleshoot` already routes readers to reports/API.
- mirror semantic equivalence: Chinese and English mirrors both remain unchanged for the same reason.
- missing required doc decision: not applicable
- missing required doc rationale: no required docs are missing.
- navigation decision: not applicable
- action: reviewed-no-change
- validation plan: run mapped pre-change gate; no placement validation is needed for this no-change group.
- post-change placement check: not applicable

### Decision group: tidas-import-schema-contract - TIDAS process supply volume import contract

- groupId: tidas-import-schema-contract
- groupName: TIDAS process supply volume import contract
- grouping basis: same OpenAPI import contract pages, same schema field, related source/SDK PR family, and same Chinese/English mirror ownership
- covered ledger keys:
  - `tiangong-lca-next-docs/docs/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-tools#51`
  - `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-tools#51`
  - `tiangong-lca-next-docs/docs/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-sdk#62`
  - `tiangong-lca-next-docs/i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-sdk#62`
- scanner input: rule `user-docs-openapi-tidas-package-import`; required docs `docs/openapi/tidas-package-import.md` and English mirror; matched files `tidas-tools/src/tidas_tools/tidas/schemas/tidas_processes.json`, `tidas-sdk/sdks/python/src/tidas_sdk/generated/tidas_processes.py`, `tidas-sdk/sdks/python/src/tidas_sdk/schemas/tidas_processes.json`, `tidas-sdk/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_processes.json`, `tidas-sdk/sdks/typescript/src/schemas/tidas_processes.schema.ts`, `tidas-sdk/sdks/typescript/src/types/tidas_processes.ts`
- per-source evidence: `tiangong-lca/tidas-tools#51`; source version `mergeCommit` `1d8e5273dd280807de269d83ac7588926b4ea709`; source worktree `/Users/foreveryoung/tiangong/automation-worktree1/docs-impact/issue-311/source-evidence/tidas-tools/pr-51`; checked code context `src/tidas_tools/tidas/schemas/tidas_processes.json` and `tests/test_validate.py`. `tiangong-lca/tidas-sdk#62`; source version `mergeCommit` `b181394e66d1059a8b4af2d12cba92368650a1e1`; source worktree `/Users/foreveryoung/tiangong/automation-worktree1/docs-impact/issue-311/source-evidence/tidas-sdk/pr-62`; checked code context `sdks/python/src/tidas_sdk/generated/tidas_processes.py`, `sdks/python/src/tidas_sdk/schemas/tidas_processes.json`, `sdks/typescript/src/runtime-assets/tidas/schemas/tidas_processes.json`, `sdks/typescript/src/schemas/tidas_processes.schema.ts`, and `sdks/typescript/src/types/tidas_processes.ts`.
- combined business impact: API/package producers must serialize `annualSupplyOrProductionVolume` under `processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness` as a numeric `Real` value, and must include it when that section is present; previous multilingual text payloads will fail schema validation.
- user-visible impact: yes
- target: next-docs OpenAPI page
- target file: `docs/openapi/tidas-package-import.md`
- mirror file: `i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md`
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: page documents API authentication, upload/enqueue/polling flow, import report semantics, validation failure payloads, and implementation notes for API clients.
- page structure map: H1 TIDAS package import API; H2 use cases; H2 auth/base URL; H2 flow overview; H2 prepare upload; H2 upload ZIP; H2 enqueue; H2 poll job status; H2 import report semantics; H2 validation failure example; H2 common implementation notes.
- relevant existing content reviewed: validation failure example and client recommendations already explain schema errors at a category/file/location level, but no current claim names process dataset field-level requirements.
- affected existing claims: partial
- existing-claim reconciliation: add field-specific schema note under validation failure guidance without changing the async flow or report semantics.
- edit operation: add-new
- why not only update existing content: the existing validation failure example is a generic sample; the source change introduces a specific compatibility note that should not replace the general example.
- selected edit target: add a short subsection after client recommendations in `校验失败响应示例` / `Validation Failure Example`, before implementation notes.
- new content type: API / schema behavior
- placement candidates: `导入报告与结果语义` was rejected because it explains result classes rather than schema preparation; `常见注意事项` was rejected because the field requirement belongs next to validation failure handling.
- placement decision: new same-level subheading inside existing validation failure section
- selected placement: after the client recommendations list and before `## 常见注意事项` / `## Implementation Notes`; add the new mirror subheadings `### 流程数据集字段兼容性` and `### Process Dataset Field Compatibility`.
- heading path: `校验失败响应示例 > 流程数据集字段兼容性`
- insertion point: after complete reader block containing validation failure JSON example plus client recommendations
- mirror placement: `Validation Failure Example > Process Dataset Field Compatibility`
- reader block boundary: do not split the JSON example or the following client recommendation list; insert after that complete validation reader block.
- placement rationale: this location keeps the new schema requirement with validation failures and package preparation guidance while preserving existing flow documentation.
- rejected placements: top-level flow overview, prepare upload, enqueue, import report semantics, and common notes were considered but are less specific to schema validation.
- mirror semantic equivalence: Chinese and English edits update the same field requirement and compatibility warning.
- missing required doc decision: not applicable
- missing required doc rationale: no required docs are missing.
- navigation decision: not applicable
- action: update-docs
- validation plan: run mapped pre-change gate, edit Chinese and English OpenAPI pages, stage only those Markdown files, run pre-commit placement validation, commit, run post-commit placement validation, next-docs preflight commands, docpact checks, PR marker validation, and result recording.
- post-change placement check: verify actual diff matches declared heading paths, mirror alignment, no undeclared H1-H6 beyond declared subsection, and no reader block split.

<!-- docs-impact-pre-change-summary:end -->

<!-- docs-impact-local-apply-mapped:v1
{
  "docsImpactIssue": "tiangong-lca/workspace#311",
  "sourcePullRequests": [
    "tiangong-lca/tidas-tools#51",
    "tiangong-lca/tidas-sdk#62"
  ],
  "ruleIds": [
    "user-docs-openapi-tidas-package-import",
    "user-docs-tidas-package-workflow"
  ],
  "localWorker": true
}
-->
