### PR TITLE
docs: add Context7 source metadata

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-25"
-lastReviewedCommit: "a82fe667a1e836ea9be8b31727fe6f1b0d70b707"
+lastReviewedCommit: "3c79b5c1091b38868810ea764d7fcb1a0ae6e236"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-25"
-lastReviewedCommit: "3c79b5c1091b38868810ea764d7fcb1a0ae6e236"
+lastReviewedCommit: "ff5d6407fe94f0e0b11cd5d6f77a0c3835f84772"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: a82fe667a1e836ea9be8b31727fe6f1b0d70b707
+lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
+lastReviewedCommit: ff5d6407fe94f0e0b11cd5d6f77a0c3835f84772
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - context7.json
   - static/llms.txt
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: a82fe667a1e836ea9be8b31727fe6f1b0d70b707
+lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
 related:
   - AGENTS.md
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - context7.json
   - static/llms.txt
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
+lastReviewedCommit: ff5d6407fe94f0e0b11cd5d6f77a0c3835f84772
 related:
   - AGENTS.md
   - docs/agents/repo-validation.md

--- a/TODO.docs-system-gaps.md
+++ b/TODO.docs-system-gaps.md
@@ -21,7 +21,7 @@ checkPaths:
   - context7.json
   - static/llms.txt
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: 900f3c354a30bfb35baf4504448de0d8940dbd90
+lastReviewedCommit: ff5d6407fe94f0e0b11cd5d6f77a0c3835f84772
 related:
   - AGENTS.md
   - README.md

--- a/context7.json
+++ b/context7.json
@@ -29,5 +29,7 @@
     "Use only public Docusaurus docs pages; do not expose internal agent, planning, incident, TODO, or governance execution records.",
     "Treat zh-CN docs under docs/ as the source of truth and /en pages as maintained English mirrors.",
     "Prefer stable user-facing pages, OpenAPI guides, MCP guides, deployment docs, FAQ, and changelog entries for answers."
-  ]
+  ],
+  "url": "https://context7.com/linancn/tiangong-lca-next-docs",
+  "public_key": "pk_PLfrQ8NexLhqPMtpyCSO2"
 }

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: a82fe667a1e836ea9be8b31727fe6f1b0d70b707
+lastReviewedCommit: ff5d6407fe94f0e0b11cd5d6f77a0c3835f84772
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: a82fe667a1e836ea9be8b31727fe6f1b0d70b707
+lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
+lastReviewedCommit: ff5d6407fe94f0e0b11cd5d6f77a0c3835f84772
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -21,7 +21,7 @@ checkPaths:
   - context7.json
   - static/llms.txt
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
+lastReviewedCommit: ff5d6407fe94f0e0b11cd5d6f77a0c3835f84772
 related:
   - i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
   - docs/agents/repo-validation.md

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -21,7 +21,7 @@ checkPaths:
   - context7.json
   - static/llms.txt
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: a82fe667a1e836ea9be8b31727fe6f1b0d70b707
+lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
 related:
   - i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
   - docs/agents/repo-validation.md

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
@@ -21,7 +21,7 @@ checkPaths:
   - context7.json
   - static/llms.txt
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
+lastReviewedCommit: ff5d6407fe94f0e0b11cd5d6f77a0c3835f84772
 related:
   - docs/dev/dev-env.md
   - docs/agents/repo-validation.md

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
@@ -21,7 +21,7 @@ checkPaths:
   - context7.json
   - static/llms.txt
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: a82fe667a1e836ea9be8b31727fe6f1b0d70b707
+lastReviewedCommit: 3c79b5c1091b38868810ea764d7fcb1a0ae6e236
 related:
   - docs/dev/dev-env.md
   - docs/agents/repo-validation.md


### PR DESCRIPTION
## Summary
- add the Context7 URL and public key to `context7.json`
- record docpact review evidence for the publication-pipeline docs touched by this change

## Validation
- `scripts/docpact validate-config --root . --strict`
- `scripts/docpact lint --root . --base origin/main --head HEAD --mode enforce`
- `npm run docs:llms:check`
- `npm run docs:publication-scope:check`

## Notes
Direct push to `linancn/tiangong-lca-next-docs:main` was denied for `ForeverYoung5`, so this PR uses the fork branch `ForeverYoung5:codex/context7-source-config`.