### PR TITLE
fix: refresh Context7 without branch override

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -380,7 +380,7 @@ jobs:
             exit 0
           fi
 
-          node -e "console.log(JSON.stringify({libraryName: process.env.CONTEXT7_LIBRARY_NAME, branch: 'main'}))" > /tmp/context7-refresh.json
+          node -e "console.log(JSON.stringify({libraryName: process.env.CONTEXT7_LIBRARY_NAME}))" > /tmp/context7-refresh.json
 
           status_code="$(curl -sS -o /tmp/context7-response.json -w '%{http_code}' \
             -X POST 'https://context7.com/api/v1/refresh' \


### PR DESCRIPTION
## Summary
- stop sending a hard-coded `branch: "main"` override to the Context7 refresh API
- keep the refresh payload scoped to the Context7 library name so the library's configured default branch is used

## Context
The publish workflow was failing after docs deploy with:

```json
{"error":"branch-not-found","message":"Failed to refresh library"}
```

Manual verification showed the same API key can read `/linancn/tiangong-lca-next-docs`, and that refresh succeeds when the payload is `{"libraryName":"/linancn/tiangong-lca-next-docs"}` but fails when `branch: "main"` is included.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('tiangong-lca-next-docs/.github/workflows/publish-docs.yml'); puts 'yaml ok'"`
- `git -C tiangong-lca-next-docs diff --check -- .github/workflows/publish-docs.yml`
- verified generated refresh payload no longer includes `branch`

## Follow-up
- After merge, lca-workspace should bump the `tiangong-lca-next-docs` submodule pointer if this repo change needs to be represented in the root workspace snapshot.

Closes #73
