### PR TITLE
docs: replay issue 321 CLI and MCP coverage

### DIFF
--- a/docs/MCP/lca_local.md
+++ b/docs/MCP/lca_local.md
@@ -72,6 +72,19 @@ sidebar_position: 3
     npx -p @tiangong-lca/mcp-server tiangong-lca-mcp-http-local
     ```
 
+4. 可选 GLAD 数据集查询配置
+
+    如果需要在 MCP 工具中查询 GLAD（Global LCA Data Access）数据集，请在启动 MCP Server 前配置服务器环境变量：
+
+    ```bash
+    GLAD_API_KEY=your-glad-api-key
+    GLAD_API_BASE_URL=https://www.globallcadataaccess.org/api/v1
+    ```
+
+    `GLAD_API_BASE_URL` 通常保持默认值；只有在您的运行环境需要访问兼容代理或私有网关时才需要覆盖。GLAD 工具依赖服务器端 API Key，不要把密钥写入公开文档、聊天记录或共享配置。
+
+    配置后，工具列表中会出现 `Search_GLAD_Datasets_Tool` 和 `Get_GLAD_Dataset_Tool`。前者可按关键词、行业、格式、地区或公开可访问性筛选数据集描述；后者可通过 `refId` 和 `dataProvider` 获取单个 GLAD 数据集描述。这些工具返回的是 GLAD 数据集元数据与访问描述，不等同于把数据集导入 TianGong LCA。需要导入或转换时，请继续使用 TIDAS ZIP 或对应转换工具链。
+
 ## MCP Server的调用
 
 ### Inspector

--- a/docs/MCP/lca_remote.md
+++ b/docs/MCP/lca_remote.md
@@ -56,6 +56,13 @@ npx @modelcontextprotocol/inspector
 
     ![](img/12.png)
 
+如果远程 MCP 服务启用了 GLAD 数据集查询能力，工具列表中还会出现 `Search_GLAD_Datasets_Tool`
+和 `Get_GLAD_Dataset_Tool`。远程使用时，您仍然只需要按本页配置 TianGong MCP 的 Bearer token；
+GLAD API Key 由远程服务端配置。若列表中没有这些工具，通常表示当前远程服务尚未启用 GLAD 集成。
+
+GLAD 查询工具用于查找外部 LCA 数据集的元数据和访问描述，不会自动把外部数据写入 TianGong LCA。
+需要迁移或导入数据时，请使用 TIDAS ZIP 流程或相应转换工具链。
+
 ### Cherry Studio
 
 在[Cherry Studio官网](https://www.cherry-ai.com/download)，参照[官方文档](https://docs.cherry-ai.com/pre-basic/installation)下载软件至本地并打开。  

--- a/docs/integration/cli.md
+++ b/docs/integration/cli.md
@@ -55,6 +55,25 @@ tiangong-lca lifecyclemodel --help
 tiangong-lca review --help
 ```
 
+## 自动化质量门
+
+面向数据生产流水线时，CLI 还提供了一组适合在写入、发布或人工交接前运行的质量门命令：
+
+```bash
+tiangong-lca process identity-preflight --input ./process-preflight.json --out-dir ./process-preflight --json
+tiangong-lca flow identity-preflight --input ./flow-preflight.json --out-dir ./flow-preflight --json
+tiangong-lca process build-plan validate --input ./process-build-plan.json --out-dir ./process-build-plan --json
+tiangong-lca flow build-plan validate --input ./flow-build-plan.json --out-dir ./flow-build-plan --json
+tiangong-lca publish run --input ./publish-request.json --dry-run --json
+```
+
+- `identity-preflight` 会把目标过程或流与候选数据对比，输出是否可自动复用、需要人工复核或应阻止新建的判定。
+- `build-plan validate` 用于检查过程或流构建计划是否包含身份判定、证据绑定、名称计划和必要的参考流 / 流属性信息。
+- `publish run --dry-run` 会输出发布规则集的校验结果，适合在真正写入或发布前做流水线拦截。
+
+这些命令会把机器可读报告写入 `--out-dir` 下的 `outputs/` 或 `reports/` 目录。接入自动化时，应优先读取报告中的
+`status`、`blockers`、`issues`、`files` 和具体制品路径。
+
 ## 校验与失败报告
 
 `dataset validate`、`process save-draft`、`lifecyclemodel save-draft` 以及相关修复命令会先进行本地 TIDAS schema 校验。当前 CLI 在快速校验失败后，会使用 SDK 的深度校验补充更具体的问题路径和消息。

--- a/i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_local.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_local.md
@@ -72,6 +72,19 @@ Depending on your system type, download nvm to your local machine from the corre
     npx -p @tiangong-lca/mcp-server tiangong-lca-mcp-http-local
     ```
 
+4. Optional GLAD dataset search configuration
+
+    To query GLAD (Global LCA Data Access) datasets from MCP tools, configure these server environment variables before starting MCP Server:
+
+    ```bash
+    GLAD_API_KEY=your-glad-api-key
+    GLAD_API_BASE_URL=https://www.globallcadataaccess.org/api/v1
+    ```
+
+    `GLAD_API_BASE_URL` usually stays at the default value. Override it only when your runtime must use a compatible proxy or private gateway. GLAD tools depend on a server-side API key; do not put the key in public docs, chat logs, or shared configuration.
+
+    After configuration, the tool list includes `Search_GLAD_Datasets_Tool` and `Get_GLAD_Dataset_Tool`. Use the search tool to filter dataset descriptors by keyword, sector, format, geography, or public accessibility. Use the get tool with `refId` and `dataProvider` to fetch one GLAD dataset descriptor. These tools return GLAD dataset metadata and access descriptions. They do not import the dataset into TianGong LCA. Use the TIDAS ZIP workflow or the appropriate conversion toolchain when you need to import or convert data.
+
 ## MCP Server Invocation
 
 ### Inspector

--- a/i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_remote.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_remote.md
@@ -57,6 +57,10 @@ npx @modelcontextprotocol/inspector
 
     ![](img/12.png)
 
+If the remote MCP service has GLAD dataset search enabled, the tool list also includes `Search_GLAD_Datasets_Tool` and `Get_GLAD_Dataset_Tool`. For remote usage, you still configure only the TianGong MCP Bearer token described on this page; the GLAD API key is configured on the remote server. If the tools are not listed, the current remote service usually has not enabled GLAD integration.
+
+GLAD query tools are for finding external LCA dataset metadata and access descriptions. They do not automatically write external data into TianGong LCA. Use the TIDAS ZIP workflow or the appropriate conversion toolchain when you need to migrate or import data.
+
 ### Cherry Studio
 
 At the [Cherry Studio official website](https://www.cherry-ai.com/download), follow the [official documentation](https://docs.cherry-ai.com/pre-basic/installation) to download the software to your local machine and open it.

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
@@ -55,6 +55,24 @@ tiangong-lca lifecyclemodel --help
 tiangong-lca review --help
 ```
 
+## Automation Gates
+
+For data-production pipelines, the CLI also provides quality-gate commands that are useful before writing data, publishing data, or handing work to a reviewer:
+
+```bash
+tiangong-lca process identity-preflight --input ./process-preflight.json --out-dir ./process-preflight --json
+tiangong-lca flow identity-preflight --input ./flow-preflight.json --out-dir ./flow-preflight --json
+tiangong-lca process build-plan validate --input ./process-build-plan.json --out-dir ./process-build-plan --json
+tiangong-lca flow build-plan validate --input ./flow-build-plan.json --out-dir ./flow-build-plan --json
+tiangong-lca publish run --input ./publish-request.json --dry-run --json
+```
+
+- `identity-preflight` compares a target process or flow with candidate data and reports whether automation can reuse it, should route it to manual review, or should block new creation.
+- `build-plan validate` checks whether a process or flow build plan includes identity decisions, evidence bindings, naming plans, and the required reference-flow or flow-property fields.
+- `publish run --dry-run` reports publish ruleset results before a real write or publish step.
+
+These commands write machine-readable reports under `outputs/` or `reports/` in the selected `--out-dir`. For automation, read fields such as `status`, `blockers`, `issues`, `files`, and artifact paths instead of relying on terminal text.
+
 ## Validation and failure reports
 
 `dataset validate`, `process save-draft`, `lifecyclemodel save-draft`, and related repair commands run local TIDAS schema validation before writing data. When fast validation fails, the current CLI uses SDK-backed deep validation to provide more specific issue paths and messages.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -4,7 +4,7 @@ Public documentation index for TianGong LCA users, integrators, and AI retrieval
 
 Source site: https://docs.tiangong.earth
 Source repository: https://github.com/linancn/tiangong-lca-next-docs
-Source commit: 276003646592c29faac905e002f779c7f6427f73
+Source commit: 949d5f1d9256e59c74297aef9e81839e6475c67b
 Publication scope: public Docusaurus docs only. Internal agent, plan, incident, TODO, and governance execution records are excluded.
 
 ## English (en)


### PR DESCRIPTION
# 重放文档影响：CLI 自动化质量门与 MCP GLAD 工具

## 摘要

- 根据已合并治理 PR tiangong-lca/workspace#326 重新匹配 issue 321 的原始 unmapped 条目。
- 新增 CLI 自动化质量门说明，并新增本地 / 远程 MCP GLAD 数据集查询工具说明。
- 同步更新中文源文档、英文镜像和 `static/llms.txt`。

## Replay source coverage

- rematched mapped items: 40
- rematched excluded files: 13
- remaining unmapped files: 0
- governance PR: tiangong-lca/workspace#326（merge 23c3bdf8bcace813a3e353e60b333904cef453c0）

## Screenshot review summary

- screenshot decision: not-needed
- source next screenshot bootstrap: not-needed
- 理由：本次实际文档更新为 CLI/MCP 命令、环境变量和工具说明；没有新增或变更需要截图解释的可视 Web UI。

## Validation notes

- next-docs dependency bootstrap: npm install
- source next screenshot bootstrap: not-needed
- pre-change decision validation: pass
- pre/post placement validation: warning，仅为英文镜像 heading equivalence 泛化告警；中文与英文镜像已同步修改同一语义块
- `npm run docs:llms`: pass，已更新 `static/llms.txt`
- `npm run docs:llms:check`: pass
- `npm run docs:publication-scope:check`: pass
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run build`: pass

## Draft reason

保持 Draft：`validate-doc-placement.rb` 对三个英文镜像返回 warning，原因是 helper 只能确认镜像文件有变更，不能自动证明翻译标题等价。已人工核对中文与英文镜像位置一致，等待人工复核后可转为 ready。

Refs tiangong-lca/workspace#321

## Pre-change decision summary

<!-- docs-impact-pre-change-summary:start -->
## Coverage group plan

| groupId | groupName | targetDocs | sourcePullRequests | groupIntent |
|---|---|---|---|---|
| grp-mcp-local-glad-tools | Local MCP GLAD dataset tools | docs/MCP/lca_local.md<br>i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_local.md | linancn/tiangong-lca-mcp#28 | update-docs |
| grp-mcp-remote-glad-tools | Remote MCP GLAD dataset tools | docs/MCP/lca_remote.md<br>i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_remote.md | linancn/tiangong-lca-mcp#28 | update-docs |
| grp-process-readiness-reviewed | Process readiness internals reviewed | docs/faq/system-models.md<br>docs/user-guide/process-analysis.md<br>i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md | linancn/tiangong-lca-worker#51<br>linancn/tiangong-lca-worker#52 | reviewed-no-change |
| grp-cli-public-gates | CLI automation gate docs | docs/integration/cli.md<br>i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md | tiangong-lca/tiangong-cli#107<br>tiangong-lca/tiangong-cli#110 | update-docs |
| grp-tidas-rulesets-reviewed | TIDAS runtime rulesets reviewed | docs/openapi/tidas-package-import.md<br>docs/user-guide/tidas-zip-workflows.md<br>i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md | tiangong-lca/tidas-sdk#74<br>tiangong-lca/tidas-tools#76 | reviewed-no-change |
| grp-data-extraction-reviewed | Dataset extraction internals reviewed | docs/user-guide/create-my-data.md<br>docs/user-guide/data-use.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | linancn/tiangong-lca-edge-functions#123 | reviewed-no-change |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/data-review.md<br>docs/user-guide/permissions-and-data-scopes.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md | linancn/tiangong-lca-worker#54<br>linancn/tiangong-lca-worker#56<br>linancn/tiangong-lca-worker#58<br>linancn/tiangong-lca-worker#60<br>tiangong-lca/database-engine#66 | reviewed-no-change |
| grp-app-url-reviewed | App URL helper reviewed | docs/user-guide/key-functions-introduction.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/key-functions-introduction.md | linancn/tiangong-lca-next#446 | reviewed-no-change |
| grp-search-embedding-reviewed | Embedding search queue internals reviewed | docs/user-guide/search.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | linancn/tiangong-lca-edge-functions#118<br>tiangong-lca/database-engine#71<br>tiangong-lca/database-engine#79 | reviewed-no-change |

## Coverage ledger

| groupId | groupName | requiredDoc | ruleId | sourcePullRequest | terminal | reason |
|---|---|---|---|---|---|---|
| grp-mcp-local-glad-tools | Local MCP GLAD dataset tools | docs/MCP/lca_local.md | user-docs-mcp-local-lca | linancn/tiangong-lca-mcp#28 | update-docs | update local GLAD env/tool guidance |
| grp-mcp-remote-glad-tools | Remote MCP GLAD dataset tools | docs/MCP/lca_remote.md | user-docs-mcp-remote-lca | linancn/tiangong-lca-mcp#28 | update-docs | update remote GLAD availability guidance |
| grp-process-readiness-reviewed | Process readiness internals reviewed | docs/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-worker#51 | reviewed-no-change | worker report contract; public provider-linking docs already accurate |
| grp-process-readiness-reviewed | Process readiness internals reviewed | docs/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-worker#52 | reviewed-no-change | worker report contract; public provider-linking docs already accurate |
| grp-cli-public-gates | CLI automation gate docs | docs/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#107 | update-docs | update CLI identity/build-plan/publish gate guidance |
| grp-cli-public-gates | CLI automation gate docs | docs/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#110 | update-docs | update CLI identity/build-plan/publish gate guidance |
| grp-tidas-rulesets-reviewed | TIDAS runtime rulesets reviewed | docs/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-sdk#74 | reviewed-no-change | runtime ruleset metadata supports tooling; import API docs unchanged |
| grp-tidas-rulesets-reviewed | TIDAS runtime rulesets reviewed | docs/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-tools#76 | reviewed-no-change | runtime ruleset metadata supports tooling; import API docs unchanged |
| grp-data-extraction-reviewed | Dataset extraction internals reviewed | docs/user-guide/create-my-data.md | user-docs-data-authoring-import-export | linancn/tiangong-lca-edge-functions#123 | reviewed-no-change | backend extraction internals; existing docs remain accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#54 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#56 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#58 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#60 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/data-review.md | user-docs-review-workflow | tiangong-lca/database-engine#66 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-data-extraction-reviewed | Dataset extraction internals reviewed | docs/user-guide/data-use.md | user-docs-data-authoring-import-export | linancn/tiangong-lca-edge-functions#123 | reviewed-no-change | backend extraction internals; existing docs remain accurate |
| grp-app-url-reviewed | App URL helper reviewed | docs/user-guide/key-functions-introduction.md | user-docs-app-shell-navigation | linancn/tiangong-lca-next#446 | reviewed-no-change | URL helper only; no visible UI docs change |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#54 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#56 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#58 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#60 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | docs/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | tiangong-lca/database-engine#66 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-process-readiness-reviewed | Process readiness internals reviewed | docs/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-worker#51 | reviewed-no-change | worker report contract; public provider-linking docs already accurate |
| grp-process-readiness-reviewed | Process readiness internals reviewed | docs/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-worker#52 | reviewed-no-change | worker report contract; public provider-linking docs already accurate |
| grp-search-embedding-reviewed | Embedding search queue internals reviewed | docs/user-guide/search.md | user-docs-search | linancn/tiangong-lca-edge-functions#118 | reviewed-no-change | embedding queue hardening; search semantics unchanged |
| grp-search-embedding-reviewed | Embedding search queue internals reviewed | docs/user-guide/search.md | user-docs-search | tiangong-lca/database-engine#71 | reviewed-no-change | embedding queue hardening; search semantics unchanged |
| grp-search-embedding-reviewed | Embedding search queue internals reviewed | docs/user-guide/search.md | user-docs-search | tiangong-lca/database-engine#79 | reviewed-no-change | embedding queue hardening; search semantics unchanged |
| grp-tidas-rulesets-reviewed | TIDAS runtime rulesets reviewed | docs/user-guide/tidas-zip-workflows.md | user-docs-tidas-package-workflow | tiangong-lca/tidas-sdk#74 | reviewed-no-change | runtime ruleset metadata supports tooling; import API docs unchanged |
| grp-tidas-rulesets-reviewed | TIDAS runtime rulesets reviewed | docs/user-guide/tidas-zip-workflows.md | user-docs-tidas-package-workflow | tiangong-lca/tidas-tools#76 | reviewed-no-change | runtime ruleset metadata supports tooling; import API docs unchanged |
| grp-mcp-local-glad-tools | Local MCP GLAD dataset tools | i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_local.md | user-docs-mcp-local-lca | linancn/tiangong-lca-mcp#28 | update-docs | update local GLAD env/tool guidance |
| grp-mcp-remote-glad-tools | Remote MCP GLAD dataset tools | i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_remote.md | user-docs-mcp-remote-lca | linancn/tiangong-lca-mcp#28 | update-docs | update remote GLAD availability guidance |
| grp-process-readiness-reviewed | Process readiness internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-worker#51 | reviewed-no-change | worker report contract; public provider-linking docs already accurate |
| grp-process-readiness-reviewed | Process readiness internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-worker#52 | reviewed-no-change | worker report contract; public provider-linking docs already accurate |
| grp-cli-public-gates | CLI automation gate docs | i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#107 | update-docs | update CLI identity/build-plan/publish gate guidance |
| grp-cli-public-gates | CLI automation gate docs | i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#110 | update-docs | update CLI identity/build-plan/publish gate guidance |
| grp-tidas-rulesets-reviewed | TIDAS runtime rulesets reviewed | i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-sdk#74 | reviewed-no-change | runtime ruleset metadata supports tooling; import API docs unchanged |
| grp-tidas-rulesets-reviewed | TIDAS runtime rulesets reviewed | i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-tools#76 | reviewed-no-change | runtime ruleset metadata supports tooling; import API docs unchanged |
| grp-data-extraction-reviewed | Dataset extraction internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md | user-docs-data-authoring-import-export | linancn/tiangong-lca-edge-functions#123 | reviewed-no-change | backend extraction internals; existing docs remain accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#54 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#56 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#58 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#60 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md | user-docs-review-workflow | tiangong-lca/database-engine#66 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-data-extraction-reviewed | Dataset extraction internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | user-docs-data-authoring-import-export | linancn/tiangong-lca-edge-functions#123 | reviewed-no-change | backend extraction internals; existing docs remain accurate |
| grp-app-url-reviewed | App URL helper reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/key-functions-introduction.md | user-docs-app-shell-navigation | linancn/tiangong-lca-next#446 | reviewed-no-change | URL helper only; no visible UI docs change |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#54 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#56 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#58 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#60 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-review-gate-reviewed | Review-submit gate internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | tiangong-lca/database-engine#66 | reviewed-no-change | review gate internals; submission/role docs already accurate |
| grp-process-readiness-reviewed | Process readiness internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-worker#51 | reviewed-no-change | worker report contract; public provider-linking docs already accurate |
| grp-process-readiness-reviewed | Process readiness internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-worker#52 | reviewed-no-change | worker report contract; public provider-linking docs already accurate |
| grp-search-embedding-reviewed | Embedding search queue internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | user-docs-search | linancn/tiangong-lca-edge-functions#118 | reviewed-no-change | embedding queue hardening; search semantics unchanged |
| grp-search-embedding-reviewed | Embedding search queue internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | user-docs-search | tiangong-lca/database-engine#71 | reviewed-no-change | embedding queue hardening; search semantics unchanged |
| grp-search-embedding-reviewed | Embedding search queue internals reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | user-docs-search | tiangong-lca/database-engine#79 | reviewed-no-change | embedding queue hardening; search semantics unchanged |
| grp-tidas-rulesets-reviewed | TIDAS runtime rulesets reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md | user-docs-tidas-package-workflow | tiangong-lca/tidas-sdk#74 | reviewed-no-change | runtime ruleset metadata supports tooling; import API docs unchanged |
| grp-tidas-rulesets-reviewed | TIDAS runtime rulesets reviewed | i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md | user-docs-tidas-package-workflow | tiangong-lca/tidas-tools#76 | reviewed-no-change | runtime ruleset metadata supports tooling; import API docs unchanged |

### Decision group: grp-mcp-local-glad-tools — Local MCP GLAD dataset tools

- groupId: grp-mcp-local-glad-tools
- groupName: Local MCP GLAD dataset tools
- grouping basis: same target docs/rule family
- covered ledger keys:
  - docs/MCP/lca_local.md|user-docs-mcp-local-lca|linancn/tiangong-lca-mcp#28
  - i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_local.md|user-docs-mcp-local-lca|linancn/tiangong-lca-mcp#28
- scanner input: user-docs-mcp-local-lca; replay rematch from original unmapped entries
- per-source evidence: source version and checked code context from prepared source worktrees; full paths recorded in worker decision file
- combined business impact: update local GLAD env/tool guidance
- user-visible impact: yes
- target: next-docs public docs
- target file: docs/MCP/lca_local.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_local.md
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: public reader guidance for the mapped workflow
- page structure map: affected heading and adjacent reader blocks reviewed
- relevant existing content reviewed: existing claims and screenshots checked
- affected existing claims: partial
- existing-claim reconciliation: add only because no existing claim covers the source-backed behavior
- edit operation: add-new
- why not only update existing content: no existing paragraph covers this behavior
- selected edit target: source-backed paragraph/list addition
- new content type: usage guidance
- placement candidates: accepted adjacent public-doc section; rejected unrelated pages
- placement decision: existing heading
- selected placement: after complete adjacent reader block
- heading path: Node.js包
- insertion point: after complete existing heading reader block
- mirror placement: translated equivalent
- reader block boundary: no procedure, image, table, or admonition block is split
- placement rationale: semantically adjacent to setup/usage guidance
- rejected placements: unrelated screenshots, client-specific sections, governance docs
- mirror semantic equivalence: Chinese and English edits cover the same claim/workflow
- screenshot decision: not-needed
- screenshot rationale: CLI/MCP/API/internal text; exact commands/tool names are sufficient; existing screenshots unchanged or unrelated
- screenshot target: not applicable
- screenshot asset action: none
- screenshot asset path: not applicable
- screenshot capture source: not applicable
- screenshot privacy check: not applicable
- screenshot coverage:
  - entry: not-needed
  - page-overview: not-needed
- missing required doc decision: not applicable
- missing required doc rationale: all required docs exist
- navigation decision: not applicable
- action: update-docs
- reason: update local GLAD env/tool guidance
- validation plan: pre-change, placement, next-docs preflight, marker validation, result recording
- post-change placement check: public Markdown diff only; warnings recorded

### Decision group: grp-mcp-remote-glad-tools — Remote MCP GLAD dataset tools

- groupId: grp-mcp-remote-glad-tools
- groupName: Remote MCP GLAD dataset tools
- grouping basis: same target docs/rule family
- covered ledger keys:
  - docs/MCP/lca_remote.md|user-docs-mcp-remote-lca|linancn/tiangong-lca-mcp#28
  - i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_remote.md|user-docs-mcp-remote-lca|linancn/tiangong-lca-mcp#28
- scanner input: user-docs-mcp-remote-lca; replay rematch from original unmapped entries
- per-source evidence: source version and checked code context from prepared source worktrees; full paths recorded in worker decision file
- combined business impact: update remote GLAD availability guidance
- user-visible impact: yes
- target: next-docs public docs
- target file: docs/MCP/lca_remote.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/MCP/lca_remote.md
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: public reader guidance for the mapped workflow
- page structure map: affected heading and adjacent reader blocks reviewed
- relevant existing content reviewed: existing claims and screenshots checked
- affected existing claims: partial
- existing-claim reconciliation: add only because no existing claim covers the source-backed behavior
- edit operation: add-new
- why not only update existing content: no existing paragraph covers this behavior
- selected edit target: source-backed paragraph/list addition
- new content type: usage guidance
- placement candidates: accepted adjacent public-doc section; rejected unrelated pages
- placement decision: existing heading
- selected placement: after complete adjacent reader block
- heading path: Inspector
- insertion point: after complete existing heading reader block
- mirror placement: translated equivalent
- reader block boundary: no procedure, image, table, or admonition block is split
- placement rationale: semantically adjacent to setup/usage guidance
- rejected placements: unrelated screenshots, client-specific sections, governance docs
- mirror semantic equivalence: Chinese and English edits cover the same claim/workflow
- screenshot decision: not-needed
- screenshot rationale: CLI/MCP/API/internal text; exact commands/tool names are sufficient; existing screenshots unchanged or unrelated
- screenshot target: not applicable
- screenshot asset action: none
- screenshot asset path: not applicable
- screenshot capture source: not applicable
- screenshot privacy check: not applicable
- screenshot coverage:
  - entry: not-needed
  - page-overview: not-needed
- missing required doc decision: not applicable
- missing required doc rationale: all required docs exist
- navigation decision: not applicable
- action: update-docs
- reason: update remote GLAD availability guidance
- validation plan: pre-change, placement, next-docs preflight, marker validation, result recording
- post-change placement check: public Markdown diff only; warnings recorded

### Decision group: grp-process-readiness-reviewed — Process readiness internals reviewed

- groupId: grp-process-readiness-reviewed
- groupName: Process readiness internals reviewed
- grouping basis: same target docs/rule family
- covered ledger keys:
  - docs/faq/system-models.md|user-docs-process-workspace|linancn/tiangong-lca-worker#51
  - docs/faq/system-models.md|user-docs-process-workspace|linancn/tiangong-lca-worker#52
  - docs/user-guide/process-analysis.md|user-docs-process-workspace|linancn/tiangong-lca-worker#51
  - docs/user-guide/process-analysis.md|user-docs-process-workspace|linancn/tiangong-lca-worker#52
  - i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md|user-docs-process-workspace|linancn/tiangong-lca-worker#51
  - i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md|user-docs-process-workspace|linancn/tiangong-lca-worker#52
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md|user-docs-process-workspace|linancn/tiangong-lca-worker#51
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md|user-docs-process-workspace|linancn/tiangong-lca-worker#52
- scanner input: user-docs-process-workspace; replay rematch from original unmapped entries
- per-source evidence: source version and checked code context from prepared source worktrees; full paths recorded in worker decision file
- combined business impact: worker report contract; public provider-linking docs already accurate
- user-visible impact: no
- target: issue comment only
- target file: docs/faq/system-models.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: public reader guidance for the mapped workflow
- page structure map: affected heading and adjacent reader blocks reviewed
- relevant existing content reviewed: existing claims and screenshots checked
- affected existing claims: correct or not applicable
- existing-claim reconciliation: no public docs change
- edit operation: none
- why not only update existing content: not applicable
- selected edit target: not applicable
- new content type: not applicable
- placement candidates: accepted adjacent public-doc section; rejected unrelated pages
- placement decision: not applicable
- selected placement: not applicable
- heading path: none
- insertion point: not applicable
- mirror placement: translated equivalent
- reader block boundary: no procedure, image, table, or admonition block is split
- placement rationale: semantically adjacent to setup/usage guidance
- rejected placements: unrelated screenshots, client-specific sections, governance docs
- mirror semantic equivalence: Chinese and English edits cover the same claim/workflow
- screenshot decision: not-needed
- screenshot rationale: CLI/MCP/API/internal text; exact commands/tool names are sufficient; existing screenshots unchanged or unrelated
- screenshot target: not applicable
- screenshot asset action: none
- screenshot asset path: not applicable
- screenshot capture source: not applicable
- screenshot privacy check: not applicable
- screenshot coverage:
  - entry: not-needed
  - page-overview: not-needed
- missing required doc decision: not applicable
- missing required doc rationale: all required docs exist
- navigation decision: not applicable
- action: noop
- reason: worker report contract; public provider-linking docs already accurate
- validation plan: pre-change, placement, next-docs preflight, marker validation, result recording
- post-change placement check: public Markdown diff only; warnings recorded

### Decision group: grp-cli-public-gates — CLI automation gate docs

- groupId: grp-cli-public-gates
- groupName: CLI automation gate docs
- grouping basis: same target docs/rule family
- covered ledger keys:
  - docs/integration/cli.md|user-docs-cli-public-usage|tiangong-lca/tiangong-cli#107
  - docs/integration/cli.md|user-docs-cli-public-usage|tiangong-lca/tiangong-cli#110
  - i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md|user-docs-cli-public-usage|tiangong-lca/tiangong-cli#107
  - i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md|user-docs-cli-public-usage|tiangong-lca/tiangong-cli#110
- scanner input: user-docs-cli-public-usage; replay rematch from original unmapped entries
- per-source evidence: source version and checked code context from prepared source worktrees; full paths recorded in worker decision file
- combined business impact: update CLI identity/build-plan/publish gate guidance
- user-visible impact: yes
- target: next-docs public docs
- target file: docs/integration/cli.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: public reader guidance for the mapped workflow
- page structure map: affected heading and adjacent reader blocks reviewed
- relevant existing content reviewed: existing claims and screenshots checked
- affected existing claims: partial
- existing-claim reconciliation: add only because no existing claim covers the source-backed behavior
- edit operation: add-new
- why not only update existing content: no existing paragraph covers this behavior
- selected edit target: source-backed paragraph/list addition
- new content type: usage guidance
- placement candidates: accepted adjacent public-doc section; rejected unrelated pages
- placement decision: new same-level heading
- selected placement: after complete adjacent reader block
- heading path: 自动化质量门
- insertion point: new same-level heading after complete 常用命令 reader block
- mirror placement: translated equivalent
- reader block boundary: no procedure, image, table, or admonition block is split
- placement rationale: semantically adjacent to setup/usage guidance
- rejected placements: unrelated screenshots, client-specific sections, governance docs
- mirror semantic equivalence: Chinese and English edits cover the same claim/workflow
- screenshot decision: not-needed
- screenshot rationale: CLI/MCP/API/internal text; exact commands/tool names are sufficient; existing screenshots unchanged or unrelated
- screenshot target: not applicable
- screenshot asset action: none
- screenshot asset path: not applicable
- screenshot capture source: not applicable
- screenshot privacy check: not applicable
- screenshot coverage:
  - entry: not-needed
  - page-overview: not-needed
- missing required doc decision: not applicable
- missing required doc rationale: all required docs exist
- navigation decision: not applicable
- action: update-docs
- reason: update CLI identity/build-plan/publish gate guidance
- validation plan: pre-change, placement, next-docs preflight, marker validation, result recording
- post-change placement check: public Markdown diff only; warnings recorded

### Decision group: grp-tidas-rulesets-reviewed — TIDAS runtime rulesets reviewed

- groupId: grp-tidas-rulesets-reviewed
- groupName: TIDAS runtime rulesets reviewed
- grouping basis: same target docs/rule family
- covered ledger keys:
  - docs/openapi/tidas-package-import.md|user-docs-openapi-tidas-package-import|tiangong-lca/tidas-sdk#74
  - docs/openapi/tidas-package-import.md|user-docs-openapi-tidas-package-import|tiangong-lca/tidas-tools#76
  - docs/user-guide/tidas-zip-workflows.md|user-docs-tidas-package-workflow|tiangong-lca/tidas-sdk#74
  - docs/user-guide/tidas-zip-workflows.md|user-docs-tidas-package-workflow|tiangong-lca/tidas-tools#76
  - i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md|user-docs-openapi-tidas-package-import|tiangong-lca/tidas-sdk#74
  - i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md|user-docs-openapi-tidas-package-import|tiangong-lca/tidas-tools#76
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md|user-docs-tidas-package-workflow|tiangong-lca/tidas-sdk#74
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md|user-docs-tidas-package-workflow|tiangong-lca/tidas-tools#76
- scanner input: user-docs-openapi-tidas-package-import, user-docs-tidas-package-workflow; replay rematch from original unmapped entries
- per-source evidence: source version and checked code context from prepared source worktrees; full paths recorded in worker decision file
- combined business impact: runtime ruleset metadata supports tooling; import API docs unchanged
- user-visible impact: no
- target: issue comment only
- target file: docs/openapi/tidas-package-import.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: public reader guidance for the mapped workflow
- page structure map: affected heading and adjacent reader blocks reviewed
- relevant existing content reviewed: existing claims and screenshots checked
- affected existing claims: correct or not applicable
- existing-claim reconciliation: no public docs change
- edit operation: none
- why not only update existing content: not applicable
- selected edit target: not applicable
- new content type: not applicable
- placement candidates: accepted adjacent public-doc section; rejected unrelated pages
- placement decision: not applicable
- selected placement: not applicable
- heading path: none
- insertion point: not applicable
- mirror placement: translated equivalent
- reader block boundary: no procedure, image, table, or admonition block is split
- placement rationale: semantically adjacent to setup/usage guidance
- rejected placements: unrelated screenshots, client-specific sections, governance docs
- mirror semantic equivalence: Chinese and English edits cover the same claim/workflow
- screenshot decision: not-needed
- screenshot rationale: CLI/MCP/API/internal text; exact commands/tool names are sufficient; existing screenshots unchanged or unrelated
- screenshot target: not applicable
- screenshot asset action: none
- screenshot asset path: not applicable
- screenshot capture source: not applicable
- screenshot privacy check: not applicable
- screenshot coverage:
  - entry: not-needed
  - page-overview: not-needed
- missing required doc decision: not applicable
- missing required doc rationale: all required docs exist
- navigation decision: not applicable
- action: noop
- reason: runtime ruleset metadata supports tooling; import API docs unchanged
- validation plan: pre-change, placement, next-docs preflight, marker validation, result recording
- post-change placement check: public Markdown diff only; warnings recorded

### Decision group: grp-data-extraction-reviewed — Dataset extraction internals reviewed

- groupId: grp-data-extraction-reviewed
- groupName: Dataset extraction internals reviewed
- grouping basis: same target docs/rule family
- covered ledger keys:
  - docs/user-guide/create-my-data.md|user-docs-data-authoring-import-export|linancn/tiangong-lca-edge-functions#123
  - docs/user-guide/data-use.md|user-docs-data-authoring-import-export|linancn/tiangong-lca-edge-functions#123
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md|user-docs-data-authoring-import-export|linancn/tiangong-lca-edge-functions#123
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md|user-docs-data-authoring-import-export|linancn/tiangong-lca-edge-functions#123
- scanner input: user-docs-data-authoring-import-export; replay rematch from original unmapped entries
- per-source evidence: source version and checked code context from prepared source worktrees; full paths recorded in worker decision file
- combined business impact: backend extraction internals; existing docs remain accurate
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/create-my-data.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: public reader guidance for the mapped workflow
- page structure map: affected heading and adjacent reader blocks reviewed
- relevant existing content reviewed: existing claims and screenshots checked
- affected existing claims: correct or not applicable
- existing-claim reconciliation: no public docs change
- edit operation: none
- why not only update existing content: not applicable
- selected edit target: not applicable
- new content type: not applicable
- placement candidates: accepted adjacent public-doc section; rejected unrelated pages
- placement decision: not applicable
- selected placement: not applicable
- heading path: none
- insertion point: not applicable
- mirror placement: translated equivalent
- reader block boundary: no procedure, image, table, or admonition block is split
- placement rationale: semantically adjacent to setup/usage guidance
- rejected placements: unrelated screenshots, client-specific sections, governance docs
- mirror semantic equivalence: Chinese and English edits cover the same claim/workflow
- screenshot decision: not-needed
- screenshot rationale: CLI/MCP/API/internal text; exact commands/tool names are sufficient; existing screenshots unchanged or unrelated
- screenshot target: not applicable
- screenshot asset action: none
- screenshot asset path: not applicable
- screenshot capture source: not applicable
- screenshot privacy check: not applicable
- screenshot coverage:
  - entry: not-needed
  - page-overview: not-needed
- missing required doc decision: not applicable
- missing required doc rationale: all required docs exist
- navigation decision: not applicable
- action: noop
- reason: backend extraction internals; existing docs remain accurate
- validation plan: pre-change, placement, next-docs preflight, marker validation, result recording
- post-change placement check: public Markdown diff only; warnings recorded

### Decision group: grp-review-gate-reviewed — Review-submit gate internals reviewed

- groupId: grp-review-gate-reviewed
- groupName: Review-submit gate internals reviewed
- grouping basis: same target docs/rule family
- covered ledger keys:
  - docs/user-guide/data-review.md|user-docs-review-workflow|linancn/tiangong-lca-worker#54
  - docs/user-guide/data-review.md|user-docs-review-workflow|linancn/tiangong-lca-worker#56
  - docs/user-guide/data-review.md|user-docs-review-workflow|linancn/tiangong-lca-worker#58
  - docs/user-guide/data-review.md|user-docs-review-workflow|linancn/tiangong-lca-worker#60
  - docs/user-guide/data-review.md|user-docs-review-workflow|tiangong-lca/database-engine#66
  - docs/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|linancn/tiangong-lca-worker#54
  - docs/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|linancn/tiangong-lca-worker#56
  - docs/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|linancn/tiangong-lca-worker#58
  - docs/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|linancn/tiangong-lca-worker#60
  - docs/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|tiangong-lca/database-engine#66
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md|user-docs-review-workflow|linancn/tiangong-lca-worker#54
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md|user-docs-review-workflow|linancn/tiangong-lca-worker#56
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md|user-docs-review-workflow|linancn/tiangong-lca-worker#58
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md|user-docs-review-workflow|linancn/tiangong-lca-worker#60
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md|user-docs-review-workflow|tiangong-lca/database-engine#66
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|linancn/tiangong-lca-worker#54
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|linancn/tiangong-lca-worker#56
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|linancn/tiangong-lca-worker#58
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|linancn/tiangong-lca-worker#60
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md|user-docs-review-workflow|tiangong-lca/database-engine#66
- scanner input: user-docs-review-workflow; replay rematch from original unmapped entries
- per-source evidence: source version and checked code context from prepared source worktrees; full paths recorded in worker decision file
- combined business impact: review gate internals; submission/role docs already accurate
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/data-review.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: public reader guidance for the mapped workflow
- page structure map: affected heading and adjacent reader blocks reviewed
- relevant existing content reviewed: existing claims and screenshots checked
- affected existing claims: correct or not applicable
- existing-claim reconciliation: no public docs change
- edit operation: none
- why not only update existing content: not applicable
- selected edit target: not applicable
- new content type: not applicable
- placement candidates: accepted adjacent public-doc section; rejected unrelated pages
- placement decision: not applicable
- selected placement: not applicable
- heading path: none
- insertion point: not applicable
- mirror placement: translated equivalent
- reader block boundary: no procedure, image, table, or admonition block is split
- placement rationale: semantically adjacent to setup/usage guidance
- rejected placements: unrelated screenshots, client-specific sections, governance docs
- mirror semantic equivalence: Chinese and English edits cover the same claim/workflow
- screenshot decision: not-needed
- screenshot rationale: CLI/MCP/API/internal text; exact commands/tool names are sufficient; existing screenshots unchanged or unrelated
- screenshot target: not applicable
- screenshot asset action: none
- screenshot asset path: not applicable
- screenshot capture source: not applicable
- screenshot privacy check: not applicable
- screenshot coverage:
  - entry: not-needed
  - page-overview: not-needed
- missing required doc decision: not applicable
- missing required doc rationale: all required docs exist
- navigation decision: not applicable
- action: noop
- reason: review gate internals; submission/role docs already accurate
- validation plan: pre-change, placement, next-docs preflight, marker validation, result recording
- post-change placement check: public Markdown diff only; warnings recorded

### Decision group: grp-app-url-reviewed — App URL helper reviewed

- groupId: grp-app-url-reviewed
- groupName: App URL helper reviewed
- grouping basis: same target docs/rule family
- covered ledger keys:
  - docs/user-guide/key-functions-introduction.md|user-docs-app-shell-navigation|linancn/tiangong-lca-next#446
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/key-functions-introduction.md|user-docs-app-shell-navigation|linancn/tiangong-lca-next#446
- scanner input: user-docs-app-shell-navigation; replay rematch from original unmapped entries
- per-source evidence: source version and checked code context from prepared source worktrees; full paths recorded in worker decision file
- combined business impact: URL helper only; no visible UI docs change
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/key-functions-introduction.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/user-guide/key-functions-introduction.md
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: public reader guidance for the mapped workflow
- page structure map: affected heading and adjacent reader blocks reviewed
- relevant existing content reviewed: existing claims and screenshots checked
- affected existing claims: correct or not applicable
- existing-claim reconciliation: no public docs change
- edit operation: none
- why not only update existing content: not applicable
- selected edit target: not applicable
- new content type: not applicable
- placement candidates: accepted adjacent public-doc section; rejected unrelated pages
- placement decision: not applicable
- selected placement: not applicable
- heading path: none
- insertion point: not applicable
- mirror placement: translated equivalent
- reader block boundary: no procedure, image, table, or admonition block is split
- placement rationale: semantically adjacent to setup/usage guidance
- rejected placements: unrelated screenshots, client-specific sections, governance docs
- mirror semantic equivalence: Chinese and English edits cover the same claim/workflow
- screenshot decision: not-needed
- screenshot rationale: CLI/MCP/API/internal text; exact commands/tool names are sufficient; existing screenshots unchanged or unrelated
- screenshot target: not applicable
- screenshot asset action: none
- screenshot asset path: not applicable
- screenshot capture source: not applicable
- screenshot privacy check: not applicable
- screenshot coverage:
  - entry: not-needed
  - page-overview: not-needed
- missing required doc decision: not applicable
- missing required doc rationale: all required docs exist
- navigation decision: not applicable
- action: noop
- reason: URL helper only; no visible UI docs change
- validation plan: pre-change, placement, next-docs preflight, marker validation, result recording
- post-change placement check: public Markdown diff only; warnings recorded

### Decision group: grp-search-embedding-reviewed — Embedding search queue internals reviewed

- groupId: grp-search-embedding-reviewed
- groupName: Embedding search queue internals reviewed
- grouping basis: same target docs/rule family
- covered ledger keys:
  - docs/user-guide/search.md|user-docs-search|linancn/tiangong-lca-edge-functions#118
  - docs/user-guide/search.md|user-docs-search|tiangong-lca/database-engine#71
  - docs/user-guide/search.md|user-docs-search|tiangong-lca/database-engine#79
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md|user-docs-search|linancn/tiangong-lca-edge-functions#118
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md|user-docs-search|tiangong-lca/database-engine#71
  - i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md|user-docs-search|tiangong-lca/database-engine#79
- scanner input: user-docs-search; replay rematch from original unmapped entries
- per-source evidence: source version and checked code context from prepared source worktrees; full paths recorded in worker decision file
- combined business impact: embedding queue hardening; search semantics unchanged
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/search.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md
- target document structure reviewed: full Chinese page and English mirror reviewed
- document purpose reviewed: public reader guidance for the mapped workflow
- page structure map: affected heading and adjacent reader blocks reviewed
- relevant existing content reviewed: existing claims and screenshots checked
- affected existing claims: correct or not applicable
- existing-claim reconciliation: no public docs change
- edit operation: none
- why not only update existing content: not applicable
- selected edit target: not applicable
- new content type: not applicable
- placement candidates: accepted adjacent public-doc section; rejected unrelated pages
- placement decision: not applicable
- selected placement: not applicable
- heading path: none
- insertion point: not applicable
- mirror placement: translated equivalent
- reader block boundary: no procedure, image, table, or admonition block is split
- placement rationale: semantically adjacent to setup/usage guidance
- rejected placements: unrelated screenshots, client-specific sections, governance docs
- mirror semantic equivalence: Chinese and English edits cover the same claim/workflow
- screenshot decision: not-needed
- screenshot rationale: CLI/MCP/API/internal text; exact commands/tool names are sufficient; existing screenshots unchanged or unrelated
- screenshot target: not applicable
- screenshot asset action: none
- screenshot asset path: not applicable
- screenshot capture source: not applicable
- screenshot privacy check: not applicable
- screenshot coverage:
  - entry: not-needed
  - page-overview: not-needed
- missing required doc decision: not applicable
- missing required doc rationale: all required docs exist
- navigation decision: not applicable
- action: noop
- reason: embedding queue hardening; search semantics unchanged
- validation plan: pre-change, placement, next-docs preflight, marker validation, result recording
- post-change placement check: public Markdown diff only; warnings recorded
<!-- docs-impact-pre-change-summary:end -->


<!-- docs-impact-local-replay-mapped:v1
{
  "docsImpactIssue": "tiangong-lca/workspace#321",
  "governancePullRequest": "tiangong-lca/workspace#326",
  "governanceMergeCommit": "23c3bdf8bcace813a3e353e60b333904cef453c0",
  "localWorker": true
}
-->
