### PR TITLE
docs: 更新 CLI 证据检索说明（docs-impact #331）

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,6 +1,6 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-29"
+lastReviewedAt: "2026-06-30"
 lastReviewedCommit: "8a1e61f29bbe0746926e8a8ca74e3e478cd8db42"
 
 catalog:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-06-30
 lastReviewedCommit: 8a1e61f29bbe0746926e8a8ca74e3e478cd8db42
 related:
   - .docpact/config.yaml

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/publication-policy.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-06-30
 lastReviewedCommit: 8a1e61f29bbe0746926e8a8ca74e3e478cd8db42
 related:
   - AGENTS.md

--- a/TODO.docs-system-gaps.md
+++ b/TODO.docs-system-gaps.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/check-publication-scope.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-06-30
 lastReviewedCommit: ca5f344ac8ad54c36fa0d9e09b230b4c72ac6f40
 related:
   - AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -32,7 +32,7 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-06-30
 lastReviewedCommit: 8a1e61f29bbe0746926e8a8ca74e3e478cd8db42
 related:
   - AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,7 +32,7 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-06-30
 lastReviewedCommit: 8a1e61f29bbe0746926e8a8ca74e3e478cd8db42
 related:
   - AGENTS.md

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/check-publication-scope.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-06-30
 lastReviewedCommit: 343f5b408d9ed74bc646171dbd6a3c14ca92adfb
 related:
   - i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md

--- a/docs/integration/cli.md
+++ b/docs/integration/cli.md
@@ -42,6 +42,8 @@ tiangong-lca search process --input ./search-process.request.json --json
 tiangong-lca flow get --id <flow-id> --version <version> --json
 tiangong-lca process list --state-code 100 --limit 20 --json
 tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir ./dataset-validate --json
+tiangong-lca dataset evidence-search plan --query "中国2026年电力结构数据" --out-dir ./evidence-search --json
+tiangong-lca dataset evidence-search run --input ./evidence-search.request.json --results ./search-results.json --out-dir ./evidence-search --json
 tiangong-lca process save-draft --input ./patched-processes.jsonl --out-dir ./process-save-draft --dry-run --json
 tiangong-lca lifecyclemodel validate-build --run-dir ./lifecyclemodel-run --json
 ```
@@ -68,7 +70,8 @@ tiangong-lca publish run --input ./publish-request.json --dry-run --json
 ```
 
 - `identity-preflight` 会把目标过程或流与候选数据对比，输出是否可自动复用、需要人工复核或应阻止新建的判定。
-- `build-plan validate` 用于检查过程或流构建计划是否包含身份判定、证据绑定、名称计划和必要的参考流 / 流属性信息。
+- `build-plan validate` 用于检查过程或流构建计划是否包含身份判定、证据绑定、名称计划、`unit_of_analysis` 决策和必要的参考流 / 流属性信息。
+- `dataset evidence-search plan/run` 用于规划字段级公开证据检索并记录外部搜索结果；CLI 负责查询矩阵、预算、结果归一化和证据声明制品，来源判断仍需由人工或 agent 工作流完成。
 - `publish run --dry-run` 会输出发布规则集的校验结果，适合在真正写入或发布前做流水线拦截。
 
 这些命令会把机器可读报告写入 `--out-dir` 下的 `outputs/` 或 `reports/` 目录。接入自动化时，应优先读取报告中的
@@ -83,5 +86,6 @@ tiangong-lca publish run --input ./publish-request.json --dry-run --json
 - 校验通过的数据仍走快速路径；
 - 校验失败的数据会尽量返回更可操作的字段路径、错误码和消息；
 - `--commit` 写入前仍会拦截 schema-invalid 行，并把失败明细写入输出目录中的 `failures.jsonl` 或校验报告。
+- `dataset evidence-search run` 会在 `outputs/` 中写出检索计划、归一化结果、报告，以及在证据不足或只有部分时写出证据声明 JSON。
 
 如果要把 CLI 结果接入流水线，请读取 JSON 输出中的 `status`、`counts`、`issues`、`files` 和各命令生成的 `outputs/**` 制品，而不是只依赖终端文本。

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
@@ -20,7 +20,7 @@ checkPaths:
   - scripts/check-publication-scope.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-06-29
+lastReviewedAt: 2026-06-30
 lastReviewedCommit: 343f5b408d9ed74bc646171dbd6a3c14ca92adfb
 related:
   - docs/dev/dev-env.md

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
@@ -42,6 +42,8 @@ tiangong-lca search process --input ./search-process.request.json --json
 tiangong-lca flow get --id <flow-id> --version <version> --json
 tiangong-lca process list --state-code 100 --limit 20 --json
 tiangong-lca dataset validate --input ./rows.jsonl --type auto --out-dir ./dataset-validate --json
+tiangong-lca dataset evidence-search plan --query "China 2026 electricity mix data" --out-dir ./evidence-search --json
+tiangong-lca dataset evidence-search run --input ./evidence-search.request.json --results ./search-results.json --out-dir ./evidence-search --json
 tiangong-lca process save-draft --input ./patched-processes.jsonl --out-dir ./process-save-draft --dry-run --json
 tiangong-lca lifecyclemodel validate-build --run-dir ./lifecyclemodel-run --json
 ```
@@ -68,7 +70,8 @@ tiangong-lca publish run --input ./publish-request.json --dry-run --json
 ```
 
 - `identity-preflight` compares a target process or flow with candidate data and reports whether automation can reuse it, should route it to manual review, or should block new creation.
-- `build-plan validate` checks whether a process or flow build plan includes identity decisions, evidence bindings, naming plans, and the required reference-flow or flow-property fields.
+- `build-plan validate` checks whether a process or flow build plan includes identity decisions, evidence bindings, naming plans, `unit_of_analysis` decisions, and the required reference-flow or flow-property fields.
+- `dataset evidence-search plan/run` plans field-level public evidence retrieval and records external search results; the CLI owns the query matrix, budget, result normalization, and evidence declaration artifacts, while human or agent workflows still own source judgement.
 - `publish run --dry-run` reports publish ruleset results before a real write or publish step.
 
 These commands write machine-readable reports under `outputs/` or `reports/` in the selected `--out-dir`. For automation, read fields such as `status`, `blockers`, `issues`, `files`, and artifact paths instead of relying on terminal text.
@@ -82,5 +85,6 @@ That means:
 - data that passes validation still uses the fast path;
 - invalid data should return more actionable field paths, issue codes, and messages;
 - before any `--commit` write, schema-invalid rows are blocked and recorded in `failures.jsonl` or the validation report under the output directory.
+- `dataset evidence-search run` writes the search plan, normalized results, report, and, when evidence is insufficient or partial, an evidence declaration JSON under `outputs/`.
 
 For pipeline integrations, read JSON fields such as `status`, `counts`, `issues`, `files`, and generated `outputs/**` artifacts instead of relying only on terminal text.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -4,7 +4,7 @@ Public documentation index for TianGong LCA users, integrators, and AI retrieval
 
 Source site: https://docs.tiangong.earth
 Source repository: https://github.com/linancn/tiangong-lca-next-docs
-Source commit: 949d5f1d9256e59c74297aef9e81839e6475c67b
+Source commit: 0809a617fd8e857e5633927aaf09dc80f02599c7
 Publication scope: public Docusaurus docs only. Internal agent, plan, incident, TODO, and governance execution records are excluded.
 
 ## English (en)


### PR DESCRIPTION
## 摘要

- 更新 CLI 文档和英文镜像：补充 `dataset evidence-search plan/run`、`unit_of_analysis` gate，以及 evidence-search 输出制品说明。
- 其余 mapped 项复核后无需公开文档改动。
- `static/llms.txt` 与 docpact review metadata 已随本次提交更新。

Refs tiangong-lca/workspace#331

## 验证

- next-docs dependency bootstrap: npm install
- source next screenshot bootstrap: not-needed
- screenshot decision: not-needed（无新增/刷新截图）
- pre-change gate: pass / complete-with-doc-edits
- placement validation pre/post commit: pass
- `npm run docs:llms`: pass; `static/llms.txt` generated
- `npm run docs:llms:check`: pass
- `npm run docs:publication-scope:check`: pass
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run build`: pass（docs 内容提交后运行；后续仅补充 docpact review metadata）
- `scripts/docpact validate-config --root . --strict`: pass
- `scripts/docpact lint --root . --base origin/main --head HEAD --mode enforce`: pass

## Pre-change decision summary

<!-- docs-impact-pre-change-summary:start -->
## Coverage group plan

| groupId | groupName | targetDocs | sourcePullRequests | groupIntent |
|---|---|---|---|---|
| grp-01-lcia-results-63 | LCIA solver result review | docs/faq/system-models.md<br>docs/user-guide/lcia.md<br>i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/lcia.md | linancn/tiangong-lca-worker#63 | Reviewed no public docs change. |
| grp-02-process-workspace-63 | Process analysis solver review | docs/faq/system-models.md<br>docs/user-guide/process-analysis.md<br>i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md | linancn/tiangong-lca-worker#63 | Reviewed no public docs change. |
| grp-03-review-workflow-63 | Review-submit gate review | docs/user-guide/data-review.md<br>docs/user-guide/permissions-and-data-scopes.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md | linancn/tiangong-lca-worker#63 | Reviewed no public docs change. |
| grp-04-data-authoring-import-export-87 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md<br>docs/user-guide/data-use.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | tiangong-lca/database-engine#87 | Reviewed no public docs change. |
| grp-05-data-catalog-reference-87 | Data catalog latest-search review | docs/user-guide/data-use.md<br>docs/user-guide/data.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data.md | tiangong-lca/database-engine#87 | Reviewed no public docs change. |
| grp-06-search-130 | Search backend contract review | docs/user-guide/search.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | linancn/tiangong-lca-edge-functions#130 | Reviewed no public docs change. |
| grp-07-data-catalog-reference-458 | Data catalog latest-search review | docs/user-guide/data-use.md<br>docs/user-guide/data.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data.md | linancn/tiangong-lca-next#458 | Reviewed no public docs change. |
| grp-08-process-workspace-458 | Process analysis solver review | docs/faq/system-models.md<br>docs/user-guide/process-analysis.md<br>i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md | linancn/tiangong-lca-next#458 | Reviewed no public docs change. |
| grp-09-data-authoring-import-export-133 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md<br>docs/user-guide/data-use.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | linancn/tiangong-lca-edge-functions#133 | Reviewed no public docs change. |
| grp-10-search-133 | Search backend contract review | docs/user-guide/search.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | linancn/tiangong-lca-edge-functions#133 | Reviewed no public docs change. |
| grp-11-data-authoring-import-export-92 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md<br>docs/user-guide/data-use.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | tiangong-lca/database-engine#92 | Reviewed no public docs change. |
| grp-12-cli-public-usage-115 | CLI evidence search command docs | docs/integration/cli.md<br>i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md | tiangong-lca/tiangong-cli#115 | Update CLI docs. |
| grp-13-cli-public-usage-112 | CLI build-plan gate review | docs/integration/cli.md<br>i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md | tiangong-lca/tiangong-cli#112 | Update CLI docs. |
| grp-14-data-authoring-import-export-95 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md<br>docs/user-guide/data-use.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | tiangong-lca/database-engine#95 | Reviewed no public docs change. |
| grp-15-process-workspace-65 | Process analysis solver review | docs/faq/system-models.md<br>docs/user-guide/process-analysis.md<br>i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md | linancn/tiangong-lca-worker#65 | Reviewed no public docs change. |
| grp-16-lcia-results-65 | LCIA solver result review | docs/faq/system-models.md<br>docs/user-guide/lcia.md<br>i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/lcia.md | linancn/tiangong-lca-worker#65 | Reviewed no public docs change. |
| grp-17-data-authoring-import-export-107 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md<br>docs/user-guide/data-use.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | tiangong-lca/database-engine#107 | Reviewed no public docs change. |
| grp-18-data-catalog-reference-107 | Data catalog latest-search review | docs/user-guide/data-use.md<br>docs/user-guide/data.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/data.md | tiangong-lca/database-engine#107 | Reviewed no public docs change. |
| grp-19-team-membership-473 | Join-team public teams review | docs/user-guide/team-function.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/team-function.md | linancn/tiangong-lca-next#473 | Reviewed no public docs change. |
| grp-20-search-147 | Search backend contract review | docs/user-guide/search.md<br>i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | linancn/tiangong-lca-edge-functions#147 | Reviewed no public docs change. |

## Action coverage

- `update-docs`: CLI public usage rows for tiangong-lca/tiangong-cli#112 and #115.
- `reviewed-no-change`: backend, database, solver, search, and Next team/search rows where existing docs remain accurate or source impact is internal.

## Coverage ledger

| groupId | groupName | requiredDoc | ruleId | sourcePullRequest | terminal | reason |
|---|---|---|---|---|---|---|
| grp-13-cli-public-usage-112 | CLI build-plan gate review | docs/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#112 | update-docs | unit_of_analysis build-plan gate needed CLI docs note. |
| grp-13-cli-public-usage-112 | CLI build-plan gate review | i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#112 | update-docs | unit_of_analysis build-plan gate needed CLI docs note. |
| grp-12-cli-public-usage-115 | CLI evidence search command docs | docs/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#115 | update-docs | CLI evidence-search command was missing from public CLI docs. |
| grp-12-cli-public-usage-115 | CLI evidence search command docs | i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#115 | update-docs | CLI evidence-search command was missing from public CLI docs. |
| grp-09-data-authoring-import-export-133 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md | user-docs-data-authoring-import-export | linancn/tiangong-lca-edge-functions#133 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-09-data-authoring-import-export-133 | Dataset extraction/search storage review | docs/user-guide/data-use.md | user-docs-data-authoring-import-export | linancn/tiangong-lca-edge-functions#133 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-09-data-authoring-import-export-133 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md | user-docs-data-authoring-import-export | linancn/tiangong-lca-edge-functions#133 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-09-data-authoring-import-export-133 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | user-docs-data-authoring-import-export | linancn/tiangong-lca-edge-functions#133 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-17-data-authoring-import-export-107 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#107 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-17-data-authoring-import-export-107 | Dataset extraction/search storage review | docs/user-guide/data-use.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#107 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-17-data-authoring-import-export-107 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#107 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-17-data-authoring-import-export-107 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#107 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-04-data-authoring-import-export-87 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#87 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-04-data-authoring-import-export-87 | Dataset extraction/search storage review | docs/user-guide/data-use.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#87 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-04-data-authoring-import-export-87 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#87 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-04-data-authoring-import-export-87 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#87 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-11-data-authoring-import-export-92 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#92 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-11-data-authoring-import-export-92 | Dataset extraction/search storage review | docs/user-guide/data-use.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#92 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-11-data-authoring-import-export-92 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#92 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-11-data-authoring-import-export-92 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#92 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-14-data-authoring-import-export-95 | Dataset extraction/search storage review | docs/user-guide/create-my-data.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#95 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-14-data-authoring-import-export-95 | Dataset extraction/search storage review | docs/user-guide/data-use.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#95 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-14-data-authoring-import-export-95 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/create-my-data.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#95 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-14-data-authoring-import-export-95 | Dataset extraction/search storage review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | user-docs-data-authoring-import-export | tiangong-lca/database-engine#95 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-07-data-catalog-reference-458 | Data catalog latest-search review | docs/user-guide/data-use.md | user-docs-data-catalog-reference | linancn/tiangong-lca-next#458 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-07-data-catalog-reference-458 | Data catalog latest-search review | docs/user-guide/data.md | user-docs-data-catalog-reference | linancn/tiangong-lca-next#458 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-07-data-catalog-reference-458 | Data catalog latest-search review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | user-docs-data-catalog-reference | linancn/tiangong-lca-next#458 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-07-data-catalog-reference-458 | Data catalog latest-search review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data.md | user-docs-data-catalog-reference | linancn/tiangong-lca-next#458 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-18-data-catalog-reference-107 | Data catalog latest-search review | docs/user-guide/data-use.md | user-docs-data-catalog-reference | tiangong-lca/database-engine#107 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-18-data-catalog-reference-107 | Data catalog latest-search review | docs/user-guide/data.md | user-docs-data-catalog-reference | tiangong-lca/database-engine#107 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-18-data-catalog-reference-107 | Data catalog latest-search review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | user-docs-data-catalog-reference | tiangong-lca/database-engine#107 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-18-data-catalog-reference-107 | Data catalog latest-search review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data.md | user-docs-data-catalog-reference | tiangong-lca/database-engine#107 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-05-data-catalog-reference-87 | Data catalog latest-search review | docs/user-guide/data-use.md | user-docs-data-catalog-reference | tiangong-lca/database-engine#87 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-05-data-catalog-reference-87 | Data catalog latest-search review | docs/user-guide/data.md | user-docs-data-catalog-reference | tiangong-lca/database-engine#87 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-05-data-catalog-reference-87 | Data catalog latest-search review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-use.md | user-docs-data-catalog-reference | tiangong-lca/database-engine#87 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-05-data-catalog-reference-87 | Data catalog latest-search review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data.md | user-docs-data-catalog-reference | tiangong-lca/database-engine#87 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-01-lcia-results-63 | LCIA solver result review | docs/faq/system-models.md | user-docs-lcia-results | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-01-lcia-results-63 | LCIA solver result review | docs/user-guide/lcia.md | user-docs-lcia-results | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-01-lcia-results-63 | LCIA solver result review | i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md | user-docs-lcia-results | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-01-lcia-results-63 | LCIA solver result review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/lcia.md | user-docs-lcia-results | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-16-lcia-results-65 | LCIA solver result review | docs/faq/system-models.md | user-docs-lcia-results | linancn/tiangong-lca-worker#65 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-16-lcia-results-65 | LCIA solver result review | docs/user-guide/lcia.md | user-docs-lcia-results | linancn/tiangong-lca-worker#65 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-16-lcia-results-65 | LCIA solver result review | i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md | user-docs-lcia-results | linancn/tiangong-lca-worker#65 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-16-lcia-results-65 | LCIA solver result review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/lcia.md | user-docs-lcia-results | linancn/tiangong-lca-worker#65 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-08-process-workspace-458 | Process analysis solver review | docs/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-next#458 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-08-process-workspace-458 | Process analysis solver review | docs/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-next#458 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-08-process-workspace-458 | Process analysis solver review | i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-next#458 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-08-process-workspace-458 | Process analysis solver review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-next#458 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-02-process-workspace-63 | Process analysis solver review | docs/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-02-process-workspace-63 | Process analysis solver review | docs/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-02-process-workspace-63 | Process analysis solver review | i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-02-process-workspace-63 | Process analysis solver review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-15-process-workspace-65 | Process analysis solver review | docs/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-worker#65 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-15-process-workspace-65 | Process analysis solver review | docs/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-worker#65 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-15-process-workspace-65 | Process analysis solver review | i18n/en/docusaurus-plugin-content-docs/current/faq/system-models.md | user-docs-process-workspace | linancn/tiangong-lca-worker#65 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-15-process-workspace-65 | Process analysis solver review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/process-analysis.md | user-docs-process-workspace | linancn/tiangong-lca-worker#65 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-03-review-workflow-63 | Review-submit gate review | docs/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-03-review-workflow-63 | Review-submit gate review | docs/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-03-review-workflow-63 | Review-submit gate review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/data-review.md | user-docs-review-workflow | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-03-review-workflow-63 | Review-submit gate review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/permissions-and-data-scopes.md | user-docs-review-workflow | linancn/tiangong-lca-worker#63 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-06-search-130 | Search backend contract review | docs/user-guide/search.md | user-docs-search | linancn/tiangong-lca-edge-functions#130 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-06-search-130 | Search backend contract review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | user-docs-search | linancn/tiangong-lca-edge-functions#130 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-10-search-133 | Search backend contract review | docs/user-guide/search.md | user-docs-search | linancn/tiangong-lca-edge-functions#133 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-10-search-133 | Search backend contract review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | user-docs-search | linancn/tiangong-lca-edge-functions#133 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-20-search-147 | Search backend contract review | docs/user-guide/search.md | user-docs-search | linancn/tiangong-lca-edge-functions#147 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-20-search-147 | Search backend contract review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/search.md | user-docs-search | linancn/tiangong-lca-edge-functions#147 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-19-team-membership-473 | Join-team public teams review | docs/user-guide/team-function.md | user-docs-team-membership | linancn/tiangong-lca-next#473 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |
| grp-19-team-membership-473 | Join-team public teams review | i18n/en/docusaurus-plugin-content-docs/current/user-guide/team-function.md | user-docs-team-membership | linancn/tiangong-lca-next#473 | reviewed-no-change | Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only. |

### Decision group: grp-01-lcia-results-63 — LCIA solver result review

- groupId: grp-01-lcia-results-63
- groupName: LCIA solver result review
- grouping basis: user-docs-lcia-results from linancn/tiangong-lca-worker#63
- per-source evidence: prepared source worktree for linancn/tiangong-lca-worker#63; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/faq/system-models.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-02-process-workspace-63 — Process analysis solver review

- groupId: grp-02-process-workspace-63
- groupName: Process analysis solver review
- grouping basis: user-docs-process-workspace from linancn/tiangong-lca-worker#63
- per-source evidence: prepared source worktree for linancn/tiangong-lca-worker#63; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/faq/system-models.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-03-review-workflow-63 — Review-submit gate review

- groupId: grp-03-review-workflow-63
- groupName: Review-submit gate review
- grouping basis: user-docs-review-workflow from linancn/tiangong-lca-worker#63
- per-source evidence: prepared source worktree for linancn/tiangong-lca-worker#63; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/data-review.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-04-data-authoring-import-export-87 — Dataset extraction/search storage review

- groupId: grp-04-data-authoring-import-export-87
- groupName: Dataset extraction/search storage review
- grouping basis: user-docs-data-authoring-import-export from tiangong-lca/database-engine#87
- per-source evidence: prepared source worktree for tiangong-lca/database-engine#87; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/create-my-data.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-05-data-catalog-reference-87 — Data catalog latest-search review

- groupId: grp-05-data-catalog-reference-87
- groupName: Data catalog latest-search review
- grouping basis: user-docs-data-catalog-reference from tiangong-lca/database-engine#87
- per-source evidence: prepared source worktree for tiangong-lca/database-engine#87; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/data-use.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-06-search-130 — Search backend contract review

- groupId: grp-06-search-130
- groupName: Search backend contract review
- grouping basis: user-docs-search from linancn/tiangong-lca-edge-functions#130
- per-source evidence: prepared source worktree for linancn/tiangong-lca-edge-functions#130; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/search.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-07-data-catalog-reference-458 — Data catalog latest-search review

- groupId: grp-07-data-catalog-reference-458
- groupName: Data catalog latest-search review
- grouping basis: user-docs-data-catalog-reference from linancn/tiangong-lca-next#458
- per-source evidence: prepared source worktree for linancn/tiangong-lca-next#458; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/data-use.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-08-process-workspace-458 — Process analysis solver review

- groupId: grp-08-process-workspace-458
- groupName: Process analysis solver review
- grouping basis: user-docs-process-workspace from linancn/tiangong-lca-next#458
- per-source evidence: prepared source worktree for linancn/tiangong-lca-next#458; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/faq/system-models.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-09-data-authoring-import-export-133 — Dataset extraction/search storage review

- groupId: grp-09-data-authoring-import-export-133
- groupName: Dataset extraction/search storage review
- grouping basis: user-docs-data-authoring-import-export from linancn/tiangong-lca-edge-functions#133
- per-source evidence: prepared source worktree for linancn/tiangong-lca-edge-functions#133; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/create-my-data.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-10-search-133 — Search backend contract review

- groupId: grp-10-search-133
- groupName: Search backend contract review
- grouping basis: user-docs-search from linancn/tiangong-lca-edge-functions#133
- per-source evidence: prepared source worktree for linancn/tiangong-lca-edge-functions#133; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/search.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-11-data-authoring-import-export-92 — Dataset extraction/search storage review

- groupId: grp-11-data-authoring-import-export-92
- groupName: Dataset extraction/search storage review
- grouping basis: user-docs-data-authoring-import-export from tiangong-lca/database-engine#92
- per-source evidence: prepared source worktree for tiangong-lca/database-engine#92; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/create-my-data.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-12-cli-public-usage-115 — CLI evidence search command docs

- groupId: grp-12-cli-public-usage-115
- groupName: CLI evidence search command docs
- grouping basis: user-docs-cli-public-usage from tiangong-lca/tiangong-cli#115
- per-source evidence: prepared source worktree for tiangong-lca/tiangong-cli#115; source version and code context reviewed.
- combined business impact: CLI evidence-search command was missing from public CLI docs.
- user-visible impact: yes
- target: next-docs CLI page
- target file: docs/integration/cli.md
- action: update-docs
- target document structure reviewed: CLI page and English mirror reviewed.
- document purpose reviewed: existing CLI page owns public command usage.
- page structure map: TianGong LCA CLI > Common commands / Automation Gates / Validation and failure reports.
- relevant existing content reviewed: command list and gate/report bullets.
- affected existing claims: incomplete command coverage.
- existing-claim reconciliation: update existing page.
- edit operation: update-existing
- selected edit target: existing CLI command and gate sections.
- placement decision: existing heading
- reader block boundary: added inside complete existing sections without splitting media/tables.
- placement rationale: CLI page owns these command examples.
- rejected placements: data user-guide pages and new page.
- mirror semantic equivalence: Chinese and English mirror update the same claims.
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-13-cli-public-usage-112 — CLI build-plan gate review

- groupId: grp-13-cli-public-usage-112
- groupName: CLI build-plan gate review
- grouping basis: user-docs-cli-public-usage from tiangong-lca/tiangong-cli#112
- per-source evidence: prepared source worktree for tiangong-lca/tiangong-cli#112; source version and code context reviewed.
- combined business impact: unit_of_analysis build-plan gate needed CLI docs note.
- user-visible impact: yes
- target: next-docs CLI page
- target file: docs/integration/cli.md
- action: update-docs
- target document structure reviewed: CLI page and English mirror reviewed.
- document purpose reviewed: existing CLI page owns public command usage.
- page structure map: TianGong LCA CLI > Common commands / Automation Gates / Validation and failure reports.
- relevant existing content reviewed: command list and gate/report bullets.
- affected existing claims: incomplete command coverage.
- existing-claim reconciliation: update existing page.
- edit operation: update-existing
- selected edit target: existing CLI command and gate sections.
- placement decision: existing heading
- reader block boundary: added inside complete existing sections without splitting media/tables.
- placement rationale: CLI page owns these command examples.
- rejected placements: data user-guide pages and new page.
- mirror semantic equivalence: Chinese and English mirror update the same claims.
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-14-data-authoring-import-export-95 — Dataset extraction/search storage review

- groupId: grp-14-data-authoring-import-export-95
- groupName: Dataset extraction/search storage review
- grouping basis: user-docs-data-authoring-import-export from tiangong-lca/database-engine#95
- per-source evidence: prepared source worktree for tiangong-lca/database-engine#95; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/create-my-data.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-15-process-workspace-65 — Process analysis solver review

- groupId: grp-15-process-workspace-65
- groupName: Process analysis solver review
- grouping basis: user-docs-process-workspace from linancn/tiangong-lca-worker#65
- per-source evidence: prepared source worktree for linancn/tiangong-lca-worker#65; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/faq/system-models.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-16-lcia-results-65 — LCIA solver result review

- groupId: grp-16-lcia-results-65
- groupName: LCIA solver result review
- grouping basis: user-docs-lcia-results from linancn/tiangong-lca-worker#65
- per-source evidence: prepared source worktree for linancn/tiangong-lca-worker#65; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/faq/system-models.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-17-data-authoring-import-export-107 — Dataset extraction/search storage review

- groupId: grp-17-data-authoring-import-export-107
- groupName: Dataset extraction/search storage review
- grouping basis: user-docs-data-authoring-import-export from tiangong-lca/database-engine#107
- per-source evidence: prepared source worktree for tiangong-lca/database-engine#107; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/create-my-data.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-18-data-catalog-reference-107 — Data catalog latest-search review

- groupId: grp-18-data-catalog-reference-107
- groupName: Data catalog latest-search review
- grouping basis: user-docs-data-catalog-reference from tiangong-lca/database-engine#107
- per-source evidence: prepared source worktree for tiangong-lca/database-engine#107; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/data-use.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-19-team-membership-473 — Join-team public teams review

- groupId: grp-19-team-membership-473
- groupName: Join-team public teams review
- grouping basis: user-docs-team-membership from linancn/tiangong-lca-next#473
- per-source evidence: prepared source worktree for linancn/tiangong-lca-next#473; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/team-function.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

### Decision group: grp-20-search-147 — Search backend contract review

- groupId: grp-20-search-147
- groupName: Search backend contract review
- grouping basis: user-docs-search from linancn/tiangong-lca-edge-functions#147
- per-source evidence: prepared source worktree for linancn/tiangong-lca-edge-functions#147; source version and code context reviewed.
- combined business impact: Source evidence reviewed; existing docs remain accurate or change is internal/backend/promote only.
- user-visible impact: no
- target: issue comment only
- target file: docs/user-guide/search.md
- action: reviewed-no-change
- screenshot decision: not-needed
- screenshot rationale: command-line docs or reviewed no-change item; no screenshot-backed UI update.
- validation plan: pre-change, placement, llms, publication scope, lint, typecheck, build, docpact, marker validation.

<!-- docs-impact-pre-change-summary:end -->

<!-- docs-impact-local-apply-mapped:v1
{
  "docsImpactIssue": "tiangong-lca/workspace#331",
  "sourcePullRequests": [
    "linancn/tiangong-lca-edge-functions#130",
    "linancn/tiangong-lca-edge-functions#133",
    "linancn/tiangong-lca-edge-functions#147",
    "linancn/tiangong-lca-next#458",
    "linancn/tiangong-lca-next#473",
    "linancn/tiangong-lca-worker#63",
    "linancn/tiangong-lca-worker#65",
    "tiangong-lca/database-engine#107",
    "tiangong-lca/database-engine#87",
    "tiangong-lca/database-engine#92",
    "tiangong-lca/database-engine#95",
    "tiangong-lca/tiangong-cli#112",
    "tiangong-lca/tiangong-cli#115"
  ],
  "ruleIds": [
    "user-docs-cli-public-usage",
    "user-docs-data-authoring-import-export",
    "user-docs-data-catalog-reference",
    "user-docs-lcia-results",
    "user-docs-process-workspace",
    "user-docs-review-workflow",
    "user-docs-search",
    "user-docs-team-membership"
  ],
  "localWorker": true
}
-->