### PR TITLE
feat: validate docs screenshot evidence

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-08"
-lastReviewedCommit: "8246f72601ead64197bfdbc5bbc861fa4e92b0dc"
+lastReviewedAt: "2026-07-23"
+lastReviewedCommit: "471aa2bd61fe7de09b78f60a11305771e265d7d6"
+lastReviewedNote: "Updated for Issue #110: repo-native screenshot manifest, bilingual asset, composition, and Markdown relationship validation now owns the screenshot evidence boundary."
 
 catalog:
   repos:
@@ -46,6 +47,8 @@ ownership:
           - scripts/generate-llms-txt.mjs
           - scripts/check-publication-scope.mjs
           - scripts/publication-policy.mjs
+          - scripts/check-screenshots.mjs
+          - scripts/check-screenshots.test.mjs
       ownerRepo: next-docs
 
     - id: local-docpact-push-gate
@@ -75,6 +78,8 @@ coverage:
     - scripts/generate-llms-txt.mjs
     - scripts/check-publication-scope.mjs
     - scripts/publication-policy.mjs
+    - scripts/check-screenshots.mjs
+    - scripts/check-screenshots.test.mjs
     - sidebars.ts
     - docusaurus.config.ts
     - src/**
@@ -119,6 +124,8 @@ routing:
         - scripts/generate-llms-txt.mjs
         - scripts/check-publication-scope.mjs
         - scripts/publication-policy.mjs
+        - scripts/check-screenshots.mjs
+        - scripts/check-screenshots.test.mjs
         - .github/workflows/publish-docs.yml
     drift-backlog:
       paths:
@@ -235,6 +242,10 @@ rules:
         kind: site-runtime-config
       - path: tsconfig.json
         kind: site-runtime-config
+      - path: scripts/check-screenshots.mjs
+        kind: docs-screenshot-validation
+      - path: scripts/check-screenshots.test.mjs
+        kind: docs-screenshot-validation-test
     requiredDocs:
       - path: AGENTS.md
         mode: review_or_update

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,14 +31,16 @@ checkPaths:
   - scripts/generate-llms-txt.mjs
   - scripts/check-publication-scope.mjs
   - scripts/publication-policy.mjs
+  - scripts/check-screenshots.mjs
+  - scripts/check-screenshots.test.mjs
   - package.json
   - .githooks/**
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 8246f72601ead64197bfdbc5bbc861fa4e92b0dc
-lastReviewedNote: "Reviewed docs-impact issue #377 public docs and llms.txt changes; repo ownership, bilingual workflow, and publication boundary remain accurate."
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 471aa2bd61fe7de09b78f60a11305771e265d7d6
+lastReviewedNote: "Updated for Issue #110: screenshot manifests now preserve the existing bilingual asset layout and composition-specific image ratios."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md
@@ -72,6 +74,7 @@ This repo owns:
 - `docs/**` as the canonical Chinese public-doc source
 - `i18n/en/docusaurus-plugin-content-docs/current/**` as the maintained English mirror
 - `sidebars.ts`, `docusaurus.config.ts`, `src/**`, and `static/**` for docs-site structure and presentation
+- `scripts/check-screenshots.mjs` for screenshot manifest, bilingual asset, image integrity, composition, and Markdown relationship validation
 - `TODO.docs-system-gaps.md` for durable tracking of product/docs drift
 
 This repo does not own:
@@ -89,7 +92,7 @@ Route those tasks to:
 
 - Repo-local documentation governance is encoded in `.docpact/config.yaml` and enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback.
 - Chinese docs are the source of truth for this site; English pages are maintained mirrors and must be updated in the same change
-- The canonical local commands are `npm run lint`, `npm run build`, `npm run typecheck`, `npm run docs:llms:check`, and `npm run docs:publication-scope:check`
+- The canonical local commands are `npm run lint`, `npm run build`, `npm run typecheck`, `npm run docs:llms:check`, `npm run docs:publication-scope:check`, and `npm run docs:screenshots:check`
 - `static/llms.txt`, `context7.json`, and `.github/workflows/publish-docs.yml` define the public AI-consumption and post-merge publication boundary
 - Use Playwright or equivalent product verification only when text inspection of `../tiangong-lca-next` is not enough to confirm the current UI flow or screenshot target
 - If a page is only partially fixed, update `TODO.docs-system-gaps.md` in the same working session
@@ -102,6 +105,7 @@ Route those tasks to:
 - Do not leave durable drift notes only in chat when `TODO.docs-system-gaps.md` should be updated
 - Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
 - Do not add internal agent docs, TODOs, plans, incidents, or governance runbooks to `static/llms.txt` or the Context7 source scope
+- Do not add or replace a public screenshot without the same-path English mirror asset and a passing screenshot manifest check
 
 ## Workspace Integration
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ checkPaths:
   - scripts/generate-llms-txt.mjs
   - scripts/check-publication-scope.mjs
   - scripts/publication-policy.mjs
+  - scripts/check-screenshots.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 8246f72601ead64197bfdbc5bbc861fa4e92b0dc
-lastReviewedNote: "Reviewed docs-impact issue #377 public docs and llms.txt changes; setup, validation, and publication commands remain accurate."
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 471aa2bd61fe7de09b78f60a11305771e265d7d6
+lastReviewedNote: "Updated for Issue #110: added the repo-native screenshot evidence validation command."
 related:
   - AGENTS.md
   - docs/agents/repo-validation.md
@@ -67,6 +68,7 @@ npm run lint:fix
 npm run docs:llms
 npm run docs:llms:check
 npm run docs:publication-scope:check
+npm run docs:screenshots:check
 npm run typecheck
 npm run build
 npm run serve
@@ -85,6 +87,19 @@ npm run docs:llms:check
 npm run docs:publication-scope:check
 npm run build
 ```
+
+When a change adds, replaces, or reuses screenshots, pass the local visual
+evidence manifest:
+
+```bash
+npm run docs:screenshots:check -- \
+  --manifest /tmp/docs-impact-visual-result.json \
+  --diff-file /tmp/docs-impact-visual.name-status
+```
+
+Without a manifest, the command succeeds as `not_applicable` when the selected
+diff has no public screenshot changes and fails if screenshot binaries changed
+without declared evidence.
 
 If navigation or page structure changes, also check:
 

--- a/TODO.docs-system-gaps.md
+++ b/TODO.docs-system-gaps.md
@@ -18,11 +18,12 @@ checkPaths:
   - i18n/en/docusaurus-plugin-content-docs/current/**
   - scripts/generate-llms-txt.mjs
   - scripts/check-publication-scope.mjs
+  - scripts/check-screenshots.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 8246f72601ead64197bfdbc5bbc861fa4e92b0dc
-lastReviewedNote: "Reviewed docs-impact issue #377 dataset-versioning and CLI import coverage; no new system-gap backlog item remains after public docs updates."
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 471aa2bd61fe7de09b78f60a11305771e265d7d6
+lastReviewedNote: "Reviewed for Issue #110: screenshot automation closes the evidence-validation gap without creating a new product/docs drift backlog item."
 related:
   - AGENTS.md
   - README.md
@@ -57,11 +58,11 @@ of truth once a gap has been identified.
 - `../tiangong-lca-next` currently publishes directly from `main`, so docs maintenance normally uses
   the product repo's `main` branch as the implementation source of truth without a separate
   production-parity check.
-- Verification credentials may exist in the repo-root `.env` file as:
-  - `TIANGONG_LCA_USERNAME`
-  - `TIANGONG_LCA_PASSWORD`
-  - `TIANGONG_LCA_API_KEY`
-- Treat these as secrets. Record variable names only, never their values.
+- Docs-impact screenshot credentials do not live in this repository. The fixed machine's root
+  workspace `.env.local` stores only `DOCS_SCREENSHOT_ENV_FILE`; the pointed-to external regular
+  file must have permissions no broader than `0600`.
+- Treat the pointer target and its values as secrets. Never copy them into a worktree, manifest,
+  issue, PR, log, or command argument.
 - If a gap requires live UI confirmation or refreshed screenshots, prefer Playwright over guesswork.
 - When adding or replacing screenshots, follow the style of existing docs screenshots and add red
   boxes or callouts when that makes the instructional focus clearer.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,14 +27,16 @@ checkPaths:
   - scripts/generate-llms-txt.mjs
   - scripts/check-publication-scope.mjs
   - scripts/publication-policy.mjs
+  - scripts/check-screenshots.mjs
+  - scripts/check-screenshots.test.mjs
   - TODO.docs-system-gaps.md
   - .githooks/pre-push
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 8246f72601ead64197bfdbc5bbc861fa4e92b0dc
-lastReviewedNote: "Reviewed docs-impact issue #377 public content changes; ownership and integration boundaries remain accurate."
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 471aa2bd61fe7de09b78f60a11305771e265d7d6
+lastReviewedNote: "Updated for Issue #110: screenshot validation now codifies mirrored page-local assets and composition-specific proportions."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -50,6 +52,7 @@ related:
 - `docs/**` is the canonical Chinese public-doc source.
 - `i18n/en/docusaurus-plugin-content-docs/current/**` is the maintained English mirror and should change with its paired Chinese page.
 - `sidebars.ts`, `docusaurus.config.ts`, `src/**`, and `static/**` define site structure, presentation, screenshots, and custom site behavior.
+- `scripts/check-screenshots.mjs` validates visual evidence without moving screenshots out of their existing page-local `img/` directories. Ordinary Chinese and English mirror assets remain byte-identical; replacements preserve their prior composition, while additions name an existing same-class reference image.
 - `static/llms.txt`, `context7.json`, `.github/workflows/publish-docs.yml`, and `scripts/*llms*` / `scripts/*publication*` define the public AI-consumption and post-merge publication boundary.
 - `TODO.docs-system-gaps.md` is the durable backlog for product/docs drift.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,6 +23,8 @@ checkPaths:
   - scripts/generate-llms-txt.mjs
   - scripts/check-publication-scope.mjs
   - scripts/publication-policy.mjs
+  - scripts/check-screenshots.mjs
+  - scripts/check-screenshots.test.mjs
   - sidebars.ts
   - docusaurus.config.ts
   - docs/**
@@ -32,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 8246f72601ead64197bfdbc5bbc861fa4e92b0dc
-lastReviewedNote: "Reviewed docs-impact issue #377 validation evidence; required local commands and docpact guidance remain accurate."
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 471aa2bd61fe7de09b78f60a11305771e265d7d6
+lastReviewedNote: "Updated for Issue #110: added screenshot manifest and bilingual asset proof."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -51,6 +53,7 @@ npm run build
 npm run typecheck
 npm run docs:llms:check
 npm run docs:publication-scope:check
+npm run docs:screenshots:check
 ```
 
 Use the narrowest command set that proves the touched area.
@@ -62,6 +65,8 @@ Use the narrowest command set that proves the touched area.
 - Publication pipeline changes require `npm run docs:llms:check` and `npm run docs:publication-scope:check`; if they affect build output, also run `npm run build` and rerun the publication-scope check afterward.
 - `static/llms.txt` must list only public docs pages, and `context7.json` must keep Context7 scoped to public docs with internal agent, TODO, plan, incident, and governance execution records excluded.
 - Product-behavior documentation changes require checking `../tiangong-lca-next` when behavior is ambiguous.
+- Screenshot additions, replacements, or reuse require `npm run docs:screenshots:check -- --manifest <visual-result.json> --diff-file <name-status.diff>`. The check owns PNG integrity and 144 DPI metadata, same-path bilingual assets, Markdown references and alt text, nearby explanatory prose, action-specific diff behavior, and composition-reference ratios.
+- Screenshot replacement must preserve the prior composition within the declared tolerance unless the manifest records an `aspectRatioChangeReason`. A new screenshot must name a repository image with the same `compositionClass`; the validator does not force unrelated screenshots into one global ratio.
 - Partial fixes to product/docs drift must update `TODO.docs-system-gaps.md`.
 - Documentation-governance changes require docpact validation.
 

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -12,17 +12,20 @@ whenToUse:
   - when publishing docs, llms.txt, or Context7 source updates
 whenToUpdate:
   - when package scripts, build commands, publish workflow, or publication-scope checks change
+  - when docs-impact screenshot validation commands or evidence contracts change
 checkPaths:
   - package.json
   - .github/workflows/build.yml
   - .github/workflows/publish-docs.yml
   - scripts/generate-llms-txt.mjs
   - scripts/check-publication-scope.mjs
+  - scripts/check-screenshots.mjs
+  - scripts/check-screenshots.test.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 8246f72601ead64197bfdbc5bbc861fa4e92b0dc
-lastReviewedNote: "Reviewed docs-impact issue #377 public docs and llms.txt changes; local dev and publication command guidance remains accurate."
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 471aa2bd61fe7de09b78f60a11305771e265d7d6
+lastReviewedNote: "Updated for issue #110 with the repo-native docs-impact screenshot test/check commands and their manifest/diff contract."
 related:
   - i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
   - docs/agents/repo-validation.md
@@ -101,6 +104,22 @@ npm run docs:publication-scope:check
 `build/llms.txt`，防止内部 agent 文档、TODO、计划、事故记录或治理执行材料进入公开 AI
 消费范围。
 
+### 检查 docs-impact 截图证据
+
+```bash
+npm run docs:screenshots:test
+npm run docs:screenshots:check
+npm run docs:screenshots:check -- \
+  --manifest /tmp/docs-impact-visual-result.json \
+  --diff-file /tmp/docs-impact-visual.name-status
+```
+
+`docs:screenshots:test` 运行截图合同回归测试。`docs:screenshots:check` 在没有 manifest 时会确认
+所选 diff 不包含文档截图变更；存在新增、替换或复用证据时，应传入本地 visual result 和
+完整 name-status diff。校验覆盖中英文页面本地资产、引用与 alt、各语言页面的邻近说明、
+144 DPI、hash、比例及 action 对应的 diff 状态。权限受阻的 Draft 例外仍由 workspace
+`validate-visual-evidence.rb` 复核本地 0600 access report。
+
 ### 自动修复可修复的 Markdown 问题
 
 ```bash
@@ -140,6 +159,7 @@ npm run write-translations -- --locale en
 
 ```bash
 npm run lint
+npm run docs:screenshots:check
 npm run docs:llms:check
 npm run docs:publication-scope:check
 npm run build

--- a/docs/dev/docs-product-sync.md
+++ b/docs/dev/docs-product-sync.md
@@ -59,6 +59,11 @@ description: 为维护者说明 docs 站点如何与 tiangong-lca-next 产品仓
 - 只记录变量名，不记录变量值
 - 不要把实际值写进文档、截图说明、提交信息或聊天摘要
 
+docs-impact 自动截图账号不使用本仓 `.env`。固定机根工作区的 `.env.local`
+只保存 `DOCS_SCREENSHOT_ENV_FILE` 指针，真实账号变量位于仓库外、权限不宽于
+`0600` 的秘密文件中，并且只由截图子进程读取。不要把秘密文件复制到 docs、
+source 或产品 worktree。
+
 ## 推荐维护流程
 
 ### 1. 先看 backlog
@@ -134,6 +139,20 @@ description: 为维护者说明 docs 站点如何与 tiangong-lca-next 产品仓
 - 对局部图，优先使用更高的采样倍率，例如 `deviceScaleFactor >= 2`，并保持与仓库既有截图接
   近的高密度 PNG 元数据（当前仓库大量旧图约为 144 DPI）。
 
+资产放置与比例规则：
+
+- 图片继续跟随页面子树。例如 `docs/user-guide/example.md` 的图片放在
+  `docs/user-guide/img/`，英文镜像放在
+  `i18n/en/docusaurus-plugin-content-docs/current/user-guide/img/`。
+- 普通英文 UI 截图在两处使用相同文件名和相同二进制内容；只有明确解释 locale
+  差异时才允许不同文件。
+- 替换图片默认保持原像素尺寸、宽高比、裁剪和视觉焦点；新增图片必须声明一个
+  同类现有图片作为 composition reference。
+- 比例按画面用途保持一致，而不是全站统一成 16:9。全屏、弹窗、控件条、标签区和
+  超宽工作区可以继续使用各自现有比例。
+- 图片放在相关段落、列表或步骤附近即可。只要至少一侧正文能够说明它支持的功能、
+  步骤、状态或结果，就不强制补写“如下图”、双侧图注或编号列表。
+
 文档目标与截图取舍原则：
 
 - 本站主要是给**人类读者**看的，因此在入口难找、结构复杂、仅靠文字不够直观时，应优先补
@@ -151,9 +170,10 @@ description: 为维护者说明 docs 站点如何与 tiangong-lca-next 产品仓
 - 审核或系统管理等隐藏入口难以仅靠文字解释
 - 现有截图已经与真实界面明显不符
 
-如果本轮只根据代码就能准确落文档，而截图工具链暂时不稳定，可以先完成文字同步，再单独补
-截图；但若该页面主要面向人类操作指导且缺图会显著影响理解，应把截图补齐作为后续高优先级工
-作。
+如果视觉判断是 `optional`，且准确文字已经足够，截图工具暂时不可用时可以明确记录
+`visual action: none`。如果判断为 `required`，不能把截图降级为普通后续项；只有账号
+已经认证成功、目标权限确实被拒绝且根 docs-impact 校验通过时，才允许保留无图的 Draft
+PR，并在同一 PR 中等待权限恢复后补图。
 
 ## 最低校验要求
 
@@ -162,6 +182,14 @@ description: 为维护者说明 docs 站点如何与 tiangong-lca-next 产品仓
 ```bash
 npm run lint
 npm run build
+```
+
+新增、替换或复用截图时还必须执行：
+
+```bash
+npm run docs:screenshots:check -- \
+  --manifest /tmp/docs-impact-visual-result.json \
+  --diff-file /tmp/docs-impact-visual.name-status
 ```
 
 如果这次同步涉及大量结构变更，也建议手动浏览本地站点，重点检查：

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
@@ -12,17 +12,20 @@ whenToUse:
   - when publishing docs, llms.txt, or Context7 source updates
 whenToUpdate:
   - when package scripts, build commands, publish workflow, or publication-scope checks change
+  - when docs-impact screenshot validation commands or evidence contracts change
 checkPaths:
   - package.json
   - .github/workflows/build.yml
   - .github/workflows/publish-docs.yml
   - scripts/generate-llms-txt.mjs
   - scripts/check-publication-scope.mjs
+  - scripts/check-screenshots.mjs
+  - scripts/check-screenshots.test.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 8246f72601ead64197bfdbc5bbc861fa4e92b0dc
-lastReviewedNote: "Reviewed docs-impact issue #377 public docs and llms.txt changes; local development guidance remains aligned with the Chinese source."
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 471aa2bd61fe7de09b78f60a11305771e265d7d6
+lastReviewedNote: "Updated for issue #110 with the repo-native docs-impact screenshot test/check commands and their manifest/diff contract."
 related:
   - docs/dev/dev-env.md
   - docs/agents/repo-validation.md
@@ -101,6 +104,24 @@ This command checks `static/llms.txt`, `sidebars.ts`, `context7.json`, and `buil
 build exists. It prevents internal agent docs, TODOs, plans, incident records, or governance
 execution material from entering the public AI-consumption scope.
 
+### Check docs-impact screenshot evidence
+
+```bash
+npm run docs:screenshots:test
+npm run docs:screenshots:check
+npm run docs:screenshots:check -- \
+  --manifest /tmp/docs-impact-visual-result.json \
+  --diff-file /tmp/docs-impact-visual.name-status
+```
+
+`docs:screenshots:test` runs the screenshot-contract regression suite. Without a manifest,
+`docs:screenshots:check` confirms that the selected diff contains no documentation screenshot
+changes. For add, replace, or reuse evidence, pass the local visual result and the complete
+name-status diff. The validator checks page-local bilingual assets, references and alt text, nearby
+explanation in each language page, 144 DPI metadata, hashes, ratios, and action-specific diff state.
+The workspace `validate-visual-evidence.rb` remains responsible for validating the local 0600 access
+report used by the access-denied Draft exception.
+
 ### Auto-fix lintable Markdown issues
 
 ```bash
@@ -140,6 +161,7 @@ For public-doc content changes, run at least:
 
 ```bash
 npm run lint
+npm run docs:screenshots:check
 npm run docs:llms:check
 npm run docs:publication-scope:check
 npm run build

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/docs-product-sync.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/docs-product-sync.md
@@ -59,6 +59,13 @@ Only two rules matter:
 - Record variable names only, never values
 - Never place actual values in docs, screenshot notes, commit messages, or summaries
 
+The docs-impact screenshot account does not use this repository's `.env`.
+The fixed machine's root-workspace `.env.local` stores only the
+`DOCS_SCREENSHOT_ENV_FILE` pointer. The real account variables stay in an
+outside-repository secret file with permissions no broader than `0600`, and
+only the screenshot child process reads it. Never copy that file into a docs,
+source, or product worktree.
+
 ## Recommended maintenance workflow
 
 ### 1. Start from the backlog
@@ -138,6 +145,26 @@ Annotation rules:
   PNG density metadata aligned with the repo's existing assets (many current screenshots are around
   144 DPI).
 
+Asset placement and composition rules:
+
+- Keep images beside their page subtree. For example, an image for
+  `docs/user-guide/example.md` belongs under `docs/user-guide/img/`, with its
+  English mirror under
+  `i18n/en/docusaurus-plugin-content-docs/current/user-guide/img/`.
+- Ordinary English-UI screenshots use the same file name and identical bytes
+  in both trees. Different binaries are allowed only for an explicitly
+  documented locale comparison.
+- A replacement keeps the prior pixel dimensions, ratio, crop, and visual
+  focus by default. A new screenshot names an existing same-class composition
+  reference.
+- Match ratios by composition purpose rather than forcing every screenshot to
+  16:9. Full screens, tall or compact modals, control strips, tabs, and
+  ultrawide workspaces retain their own established proportions.
+- Place the image near the related paragraph, list, or step. Valid prose on
+  either side is enough when it explains the supported function, step, state,
+  or result; fixed “shown below” wording, two-sided captions, and numbered
+  lists are not mandatory.
+
 Documentation goal and screenshot tradeoff:
 
 - This site is primarily for **human readers**, so screenshots should be added when they materially
@@ -157,10 +184,12 @@ Screenshots are especially useful when:
 - hidden entry points such as Review or System Management are hard to explain with text alone
 - existing screenshots are clearly out of date
 
-If the docs can be updated accurately from code inspection and the screenshot toolchain is unstable,
-complete the text sync first and add screenshots in a later pass; however, if a page is primarily a
-human task guide and the missing screenshot would materially hurt comprehension, treat screenshot
-completion as a high-priority follow-up.
+When the visual decision is `optional` and accurate text is sufficient, a
+tooling problem may be recorded with `visual action: none`. When the visual is
+`required`, do not demote it to an ordinary follow-up. A screenshot-free Draft
+PR is allowed only after successful authentication, a proven authorization
+denial, and a passing root docs-impact access validation; the same PR must gain
+the screenshot before it becomes ready.
 
 ## Minimum verification
 
@@ -169,6 +198,14 @@ After public-doc changes, run at least:
 ```bash
 npm run lint
 npm run build
+```
+
+When screenshots are added, replaced, or reused, also run:
+
+```bash
+npm run docs:screenshots:check -- \
+  --manifest /tmp/docs-impact-visual-result.json \
+  --diff-file /tmp/docs-impact-visual.name-status
 ```
 
 If the sync also changes information architecture, manually inspect the local site and verify:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "docs:llms": "node scripts/generate-llms-txt.mjs",
     "docs:llms:check": "node scripts/generate-llms-txt.mjs --check",
     "docs:publication-scope:check": "node scripts/check-publication-scope.mjs",
+    "docs:screenshots:check": "node scripts/check-screenshots.mjs",
+    "docs:screenshots:test": "node --test scripts/check-screenshots.test.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/check-screenshots.mjs
+++ b/scripts/check-screenshots.mjs
@@ -1,0 +1,844 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const VISUAL_SCHEMA = 'docs-impact-visual-result.v1';
+const MARKER_SCHEMA = 'docs-impact-visual-evidence:v1';
+const ENGLISH_DOC_PREFIX =
+  'i18n/en/docusaurus-plugin-content-docs/current/';
+const GENERIC_ALT_TEXT = new Set([
+  '',
+  'alt',
+  'alt text',
+  'image',
+  'img',
+  'picture',
+  'screenshot',
+  '图',
+  '图片',
+  '截图',
+  '替代文字',
+]);
+const PNG_SIGNATURE = '89504e470d0a1a0a';
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const WARN_IMAGE_BYTES = 2 * 1024 * 1024;
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function parseArgs(argv) {
+  const options = {
+    root: '.',
+    manifest: process.env.DOCS_SCREENSHOT_MANIFEST,
+    diffFile: undefined,
+    baseRef: process.env.DOCS_SCREENSHOT_BASE_REF || 'origin/main',
+    output: '-',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--root') options.root = argv[++index];
+    else if (argument === '--manifest') options.manifest = argv[++index];
+    else if (argument === '--diff-file') options.diffFile = argv[++index];
+    else if (argument === '--base-ref') options.baseRef = argv[++index];
+    else if (argument === '--output') options.output = argv[++index];
+    else if (argument === '--json') {
+      // JSON is the only output format. This flag makes command intent explicit.
+    } else if (argument === '--help' || argument === '-h') {
+      return { help: true };
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  return options;
+}
+
+function usage() {
+  return `Usage:
+  node scripts/check-screenshots.mjs [--root PATH] [--manifest PATH]
+    [--diff-file PATH] [--base-ref REF] [--output PATH] [--json]
+
+Without --manifest, the command passes only when the selected diff contains no
+public documentation screenshot changes.`;
+}
+
+function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function parsePng(buffer) {
+  if (
+    buffer.length < 24 ||
+    buffer.subarray(0, 8).toString('hex') !== PNG_SIGNATURE
+  ) {
+    throw new Error('file is not a readable PNG');
+  }
+
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  if (width === 0 || height === 0) {
+    throw new Error('PNG dimensions must be positive');
+  }
+
+  let dpi;
+  let offset = 8;
+  while (offset + 12 <= buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.toString('ascii', offset + 4, offset + 8);
+    const chunkEnd = offset + 12 + length;
+    if (chunkEnd > buffer.length) {
+      throw new Error(`PNG chunk ${type} exceeds file length`);
+    }
+    if (type === 'pHYs' && length >= 9) {
+      const pixelsPerMeterX = buffer.readUInt32BE(offset + 8);
+      const pixelsPerMeterY = buffer.readUInt32BE(offset + 12);
+      const unit = buffer[offset + 16];
+      if (unit === 1) {
+        dpi = {
+          x: pixelsPerMeterX * 0.0254,
+          y: pixelsPerMeterY * 0.0254,
+        };
+      }
+    }
+    offset = chunkEnd;
+    if (type === 'IEND') break;
+  }
+
+  return {
+    width,
+    height,
+    aspectRatio: width / height,
+    dpi,
+    bytes: buffer.length,
+    sha256: sha256(buffer),
+  };
+}
+
+function normalizeRepoPath(value) {
+  const normalized = path.posix
+    .normalize(String(value || '').replaceAll('\\', '/').replace(/^\.\//, ''));
+  if (
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error(`path escapes repository root: ${value}`);
+  }
+  return normalized;
+}
+
+function repoFile(root, repoPath) {
+  const normalized = normalizeRepoPath(repoPath);
+  const absoluteRoot = path.resolve(root);
+  const absolutePath = path.resolve(absoluteRoot, normalized);
+  if (
+    absolutePath !== absoluteRoot &&
+    !absolutePath.startsWith(`${absoluteRoot}${path.sep}`)
+  ) {
+    throw new Error(`path escapes repository root: ${repoPath}`);
+  }
+  return { normalized, absolutePath };
+}
+
+function expectedMirrorDoc(requiredDoc) {
+  const normalized = normalizeRepoPath(requiredDoc);
+  if (!normalized.startsWith('docs/')) {
+    throw new Error(`requiredDoc must be under docs/**: ${requiredDoc}`);
+  }
+  return `${ENGLISH_DOC_PREFIX}${normalized.slice('docs/'.length)}`;
+}
+
+function expectedImageDirectory(docPath) {
+  return path.posix.join(path.posix.dirname(normalizeRepoPath(docPath)), 'img');
+}
+
+function markdownImageReferences(markdown, docPath) {
+  const references = [];
+  const pattern = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+  const lines = markdown.split(/\r?\n/);
+
+  lines.forEach((line, lineIndex) => {
+    for (const match of line.matchAll(pattern)) {
+      let target = match[2];
+      try {
+        target = decodeURIComponent(target);
+      } catch {
+        // Keep the original value so the later path check reports it.
+      }
+      if (/^(?:https?:|data:|#)/i.test(target)) continue;
+      const resolved = target.startsWith('/')
+        ? normalizeRepoPath(`static/${target.slice(1)}`)
+        : normalizeRepoPath(
+            path.posix.join(path.posix.dirname(docPath), target),
+          );
+      references.push({
+        alt: match[1].trim(),
+        target: resolved,
+        line: lineIndex + 1,
+      });
+    }
+  });
+
+  return references;
+}
+
+function meaningfulAlt(alt) {
+  const normalized = String(alt || '').trim().toLocaleLowerCase('en-US');
+  return !GENERIC_ALT_TEXT.has(normalized) && normalized.length >= 3;
+}
+
+function normalizeNearbyLine(line) {
+  return String(line || '')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/^\s*#{1,6}\s*/, '')
+    .replace(/^\s*(?:[-*+]|\d+[.)])\s+/, '')
+    .replace(/[`*_~>|[\]()]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function hasNearbyExplanation(markdown, lineNumber) {
+  const lines = markdown.split(/\r?\n/);
+  const start = Math.max(0, lineNumber - 6);
+  const end = Math.min(lines.length, lineNumber + 5);
+  return lines
+    .slice(start, end)
+    .some((line) => {
+      const trimmed = line.trim();
+      if (
+        !trimmed ||
+        /^#{1,6}\s/.test(trimmed) ||
+        /^```/.test(trimmed) ||
+        trimmed === '---'
+      ) {
+        return false;
+      }
+      return normalizeNearbyLine(line).replace(/\s/g, '').length >= 8;
+    });
+}
+
+function parseNameStatus(text) {
+  const entries = new Map();
+  for (const line of String(text || '').split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const fields = line.split('\t');
+    if (fields.length < 2) continue;
+    const status = fields[0];
+    if (/^[RC]/.test(status) && fields.length >= 3) {
+      entries.set(normalizeRepoPath(fields[1]), 'D');
+      entries.set(normalizeRepoPath(fields[2]), 'A');
+      continue;
+    }
+    const file = normalizeRepoPath(fields.at(-1));
+    entries.set(file, status);
+  }
+  return entries;
+}
+
+function gitNameStatus(root, baseRef) {
+  const result = spawnSync(
+    'git',
+    ['diff', '--name-status', `${baseRef}...HEAD`],
+    { cwd: root, encoding: 'utf8' },
+  );
+  if (result.status !== 0) {
+    return { text: '', error: result.stderr.trim() || 'git diff failed' };
+  }
+  return { text: result.stdout, error: undefined };
+}
+
+function gitFileAt(root, ref, repoPath) {
+  const result = spawnSync('git', ['show', `${ref}:${repoPath}`], {
+    cwd: root,
+    encoding: null,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  if (result.status !== 0) return undefined;
+  return result.stdout;
+}
+
+function readManifest(manifestPath) {
+  const payload = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  if (
+    payload.schemaVersion !== VISUAL_SCHEMA &&
+    payload.schema !== MARKER_SCHEMA
+  ) {
+    throw new Error(
+      `manifest schema must be ${VISUAL_SCHEMA} or contain visual evidence captures`,
+    );
+  }
+  return payload;
+}
+
+function requireString(capture, field, errors, label) {
+  const value = capture[field];
+  if (typeof value !== 'string' || value.trim() === '') {
+    errors.push(`${label}: ${field} must be a non-empty string`);
+    return undefined;
+  }
+  return value.trim();
+}
+
+function validateCapture({
+  root,
+  capture,
+  diff,
+  baseRef,
+  errors,
+  warnings,
+}) {
+  const label = `capture ${capture.id || '<missing-id>'}`;
+  const id = requireString(capture, 'id', errors, label);
+  requireString(capture, 'groupId', errors, label);
+  const action = requireString(capture, 'action', errors, label);
+  const requiredDoc = requireString(capture, 'requiredDoc', errors, label);
+  const mirrorDoc = requireString(capture, 'mirrorDoc', errors, label);
+  const asset = requireString(capture, 'asset', errors, label);
+  const mirrorAsset = requireString(capture, 'mirrorAsset', errors, label);
+  requireString(capture, 'sourceRepo', errors, label);
+  const sourceCommit = requireString(capture, 'sourceCommit', errors, label);
+  const declaredSha256 = requireString(capture, 'sha256', errors, label);
+  requireString(capture, 'captureMode', errors, label);
+  requireString(capture, 'routePattern', errors, label);
+  requireString(capture, 'uiState', errors, label);
+  requireString(capture, 'locale', errors, label);
+  requireString(capture, 'compositionClass', errors, label);
+
+  if (!['add', 'replace', 'reuse'].includes(action)) {
+    errors.push(`${label}: action must be add, replace, or reuse`);
+  }
+  if (sourceCommit && !FULL_SHA_PATTERN.test(sourceCommit)) {
+    errors.push(`${label}: sourceCommit must be a full 40-character SHA`);
+  }
+  if (
+    !Array.isArray(capture.sourcePullRequests) ||
+    capture.sourcePullRequests.length === 0 ||
+    capture.sourcePullRequests.some(
+      (reference) => !/^[^/\s]+\/[^#\s]+#\d+$/.test(String(reference)),
+    )
+  ) {
+    errors.push(
+      `${label}: sourcePullRequests must contain owner/repo#number values`,
+    );
+  }
+  if (
+    capture.routePattern &&
+    (/[?&](?:token|key|secret|email)=/i.test(capture.routePattern) ||
+      /[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/.test(capture.routePattern) ||
+      /\b[0-9a-f]{8}-[0-9a-f-]{27,}\b/i.test(capture.routePattern))
+  ) {
+    errors.push(`${label}: routePattern contains an identifier or secret-like value`);
+  }
+
+  if (
+    !capture.viewport ||
+    !Number.isInteger(capture.viewport.width) ||
+    !Number.isInteger(capture.viewport.height) ||
+    Number(capture.viewport.deviceScaleFactor) < 2
+  ) {
+    errors.push(
+      `${label}: viewport must include integer width/height and deviceScaleFactor >= 2`,
+    );
+  }
+
+  const privacy = capture.privacyReview;
+  if (
+    !privacy ||
+    privacy.syntheticOrPublicData !== true ||
+    privacy.secretsAbsent !== true ||
+    privacy.reviewed !== true ||
+    !Array.isArray(privacy.opaqueMasksApplied)
+  ) {
+    errors.push(
+      `${label}: privacyReview must confirm synthetic/public data, opaque masks, absent secrets, and completed review`,
+    );
+  }
+
+  let normalizedRequiredDoc;
+  let normalizedMirrorDoc;
+  let normalizedAsset;
+  let normalizedMirrorAsset;
+  try {
+    normalizedRequiredDoc = normalizeRepoPath(requiredDoc);
+    normalizedMirrorDoc = normalizeRepoPath(mirrorDoc);
+    normalizedAsset = normalizeRepoPath(asset);
+    normalizedMirrorAsset = normalizeRepoPath(mirrorAsset);
+
+    const expectedMirror = expectedMirrorDoc(normalizedRequiredDoc);
+    if (normalizedMirrorDoc !== expectedMirror) {
+      errors.push(
+        `${label}: mirrorDoc must be ${expectedMirror}, got ${normalizedMirrorDoc}`,
+      );
+    }
+    if (
+      path.posix.dirname(normalizedAsset) !==
+      expectedImageDirectory(normalizedRequiredDoc)
+    ) {
+      errors.push(
+        `${label}: asset must be under ${expectedImageDirectory(normalizedRequiredDoc)}/`,
+      );
+    }
+    if (
+      path.posix.dirname(normalizedMirrorAsset) !==
+      expectedImageDirectory(normalizedMirrorDoc)
+    ) {
+      errors.push(
+        `${label}: mirrorAsset must be under ${expectedImageDirectory(normalizedMirrorDoc)}/`,
+      );
+    }
+    if (
+      path.posix.basename(normalizedAsset) !==
+      path.posix.basename(normalizedMirrorAsset)
+    ) {
+      errors.push(`${label}: asset and mirrorAsset must use the same file name`);
+    }
+    if (
+      !/^[a-z0-9]+(?:-[a-z0-9]+)*\.png$/.test(
+        path.posix.basename(normalizedAsset),
+      )
+    ) {
+      errors.push(`${label}: screenshot file name must be semantic kebab-case PNG`);
+    }
+  } catch (error) {
+    errors.push(`${label}: ${error.message}`);
+  }
+
+  if (
+    !normalizedRequiredDoc ||
+    !normalizedMirrorDoc ||
+    !normalizedAsset ||
+    !normalizedMirrorAsset
+  ) {
+    return;
+  }
+
+  let assetMetadata;
+  let mirrorMetadata;
+  for (const [kind, repoPath] of [
+    ['asset', normalizedAsset],
+    ['mirrorAsset', normalizedMirrorAsset],
+  ]) {
+    try {
+      const file = repoFile(root, repoPath);
+      if (!fs.statSync(file.absolutePath).isFile()) {
+        throw new Error('is not a regular file');
+      }
+      const metadata = parsePng(fs.readFileSync(file.absolutePath));
+      if (kind === 'asset') assetMetadata = metadata;
+      else mirrorMetadata = metadata;
+
+      if (
+        !metadata.dpi ||
+        Math.abs(metadata.dpi.x - 144) > 1 ||
+        Math.abs(metadata.dpi.y - 144) > 1
+      ) {
+        errors.push(`${label}: ${kind} must contain 144 DPI PNG metadata`);
+      }
+      if (metadata.bytes > MAX_IMAGE_BYTES) {
+        errors.push(`${label}: ${kind} exceeds the 5 MiB hard limit`);
+      } else if (metadata.bytes > WARN_IMAGE_BYTES) {
+        warnings.push(`${label}: ${kind} exceeds 2 MiB`);
+      }
+    } catch (error) {
+      errors.push(`${label}: ${kind} ${repoPath} ${error.message}`);
+    }
+  }
+
+  if (!assetMetadata || !mirrorMetadata) return;
+
+  if (!capture.localeComparison && assetMetadata.sha256 !== mirrorMetadata.sha256) {
+    errors.push(`${label}: ordinary bilingual mirror assets must have identical SHA-256`);
+  }
+  if (
+    capture.localeComparison === true &&
+    (!capture.localeComparisonReason ||
+      String(capture.localeComparisonReason).trim() === '')
+  ) {
+    errors.push(`${label}: localeComparison requires localeComparisonReason`);
+  }
+  if (
+    declaredSha256 &&
+    declaredSha256.toLowerCase() !== assetMetadata.sha256
+  ) {
+    errors.push(`${label}: sha256 does not match the asset`);
+  }
+  if (
+    !capture.outputPixels ||
+    capture.outputPixels.width !== assetMetadata.width ||
+    capture.outputPixels.height !== assetMetadata.height
+  ) {
+    errors.push(`${label}: outputPixels do not match the PNG dimensions`);
+  }
+  if (
+    !Number.isFinite(Number(capture.aspectRatio)) ||
+    Math.abs(Number(capture.aspectRatio) - assetMetadata.aspectRatio) > 0.01
+  ) {
+    errors.push(`${label}: aspectRatio does not match the PNG dimensions`);
+  }
+  if (Number(capture.dpi) !== 144) {
+    errors.push(`${label}: manifest dpi must be 144`);
+  }
+
+  let requiredMarkdown;
+  let mirrorMarkdown;
+  try {
+    requiredMarkdown = fs.readFileSync(
+      repoFile(root, normalizedRequiredDoc).absolutePath,
+      'utf8',
+    );
+  } catch (error) {
+    errors.push(`${label}: requiredDoc cannot be read: ${error.message}`);
+  }
+  try {
+    mirrorMarkdown = fs.readFileSync(
+      repoFile(root, normalizedMirrorDoc).absolutePath,
+      'utf8',
+    );
+  } catch (error) {
+    errors.push(`${label}: mirrorDoc cannot be read: ${error.message}`);
+  }
+
+  const docReferences = requiredMarkdown
+    ? markdownImageReferences(requiredMarkdown, normalizedRequiredDoc).filter(
+        (reference) => reference.target === normalizedAsset,
+      )
+    : [];
+  const mirrorReferences = mirrorMarkdown
+    ? markdownImageReferences(mirrorMarkdown, normalizedMirrorDoc).filter(
+        (reference) => reference.target === normalizedMirrorAsset,
+      )
+    : [];
+
+  if (docReferences.length === 0) {
+    errors.push(`${label}: requiredDoc does not reference asset`);
+  }
+  if (mirrorReferences.length === 0) {
+    errors.push(`${label}: mirrorDoc does not reference mirrorAsset`);
+  }
+  for (const reference of [...docReferences, ...mirrorReferences]) {
+    if (!meaningfulAlt(reference.alt)) {
+      errors.push(`${label}: image reference on line ${reference.line} has generic alt text`);
+    }
+  }
+  const requiredDocHasNearbyExplanation = docReferences.some((reference) =>
+    hasNearbyExplanation(requiredMarkdown, reference.line),
+  );
+  const mirrorDocHasNearbyExplanation = mirrorReferences.some((reference) =>
+    hasNearbyExplanation(mirrorMarkdown, reference.line),
+  );
+  if (docReferences.length > 0 && !requiredDocHasNearbyExplanation) {
+    errors.push(
+      `${label}: requiredDoc has no nearby explanatory prose for the screenshot`,
+    );
+  }
+  if (mirrorReferences.length > 0 && !mirrorDocHasNearbyExplanation) {
+    errors.push(
+      `${label}: mirrorDoc has no nearby explanatory prose for the screenshot`,
+    );
+  }
+  if (
+    Array.isArray(capture.callouts) &&
+    capture.callouts.some(
+      (callout) =>
+        !Number.isInteger(callout.number) ||
+        !String(callout.target || '').trim(),
+    )
+  ) {
+    errors.push(`${label}: every callout must include an integer number and target`);
+  }
+
+  const assetStatus = diff.get(normalizedAsset);
+  const mirrorStatus = diff.get(normalizedMirrorAsset);
+  if (action === 'add') {
+    if (!assetStatus?.startsWith('A') || !mirrorStatus?.startsWith('A')) {
+      errors.push(`${label}: add requires both mirror assets to be added in the selected diff`);
+    }
+    if (gitFileAt(root, baseRef, normalizedAsset)) {
+      errors.push(`${label}: add would overwrite an asset that already exists at ${baseRef}`);
+    }
+    const reference = requireString(
+      capture,
+      'compositionReference',
+      errors,
+      label,
+    );
+    if (reference) {
+      try {
+        const normalizedReference = normalizeRepoPath(reference);
+        const referenceBuffer = gitFileAt(root, baseRef, normalizedReference);
+        if (!referenceBuffer) {
+          throw new Error(
+            `does not exist at ${baseRef}: ${normalizedReference}`,
+          );
+        }
+        const referenceMetadata = parsePng(referenceBuffer);
+        const ratioDelta =
+          Math.abs(assetMetadata.aspectRatio - referenceMetadata.aspectRatio) /
+          referenceMetadata.aspectRatio;
+        if (ratioDelta > 0.1 && !capture.aspectRatioChangeReason) {
+          errors.push(
+            `${label}: add aspect ratio differs from compositionReference by more than 10% without aspectRatioChangeReason`,
+          );
+        }
+      } catch (error) {
+        errors.push(`${label}: compositionReference cannot be used: ${error.message}`);
+      }
+    }
+  } else if (action === 'replace') {
+    if (
+      (!assetStatus?.startsWith('M') || !mirrorStatus?.startsWith('M'))
+    ) {
+      errors.push(
+        `${label}: replace requires both mirror assets to be modified in the selected diff`,
+      );
+    }
+    const baseline = gitFileAt(root, baseRef, normalizedAsset);
+    if (!baseline) {
+      errors.push(`${label}: replace asset does not exist at ${baseRef}`);
+    } else {
+      try {
+        const baselineMetadata = parsePng(baseline);
+        if (baselineMetadata.sha256 === assetMetadata.sha256) {
+          errors.push(`${label}: replace did not change the asset hash`);
+        }
+        const ratioDelta =
+          Math.abs(assetMetadata.aspectRatio - baselineMetadata.aspectRatio) /
+          baselineMetadata.aspectRatio;
+        if (ratioDelta > 0.02 && !capture.aspectRatioChangeReason) {
+          errors.push(
+            `${label}: replace aspect ratio changed by more than 2% without aspectRatioChangeReason`,
+          );
+        }
+        if (
+          (assetMetadata.width !== baselineMetadata.width ||
+            assetMetadata.height !== baselineMetadata.height) &&
+          ratioDelta <= 0.02
+        ) {
+          warnings.push(
+            `${label}: replace preserved composition ratio but changed pixel dimensions`,
+          );
+        }
+      } catch (error) {
+        errors.push(`${label}: baseline PNG cannot be parsed: ${error.message}`);
+      }
+    }
+  } else if (action === 'reuse') {
+    if (assetStatus?.startsWith('A') || assetStatus?.startsWith('M')) {
+      warnings.push(`${label}: reuse unexpectedly changes the existing asset`);
+    }
+  }
+
+  return { id, action, asset: normalizedAsset, mirrorAsset: normalizedMirrorAsset };
+}
+
+function changedScreenshotPaths(diff) {
+  return [...diff.keys()].filter(
+    (file) =>
+      /\.(?:png|jpe?g|webp)$/i.test(file) &&
+      (file.startsWith('docs/') || file.startsWith(ENGLISH_DOC_PREFIX)),
+  );
+}
+
+export function validateScreenshotManifest({
+  root,
+  manifest,
+  diffText = '',
+  baseRef = 'origin/main',
+}) {
+  const absoluteRoot = path.resolve(root);
+  const errors = [];
+  const warnings = [];
+  const diff = parseNameStatus(diffText);
+  const captures = Array.isArray(manifest?.captures) ? manifest.captures : [];
+  const blockedCaptures = Array.isArray(manifest?.blockedCaptures)
+    ? manifest.blockedCaptures
+    : [];
+
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    errors.push('manifest must be a JSON object');
+  }
+  if (
+    manifest?.schemaVersion !== VISUAL_SCHEMA &&
+    manifest?.schema !== MARKER_SCHEMA
+  ) {
+    errors.push(
+      `manifest schema must be ${VISUAL_SCHEMA} or ${MARKER_SCHEMA}`,
+    );
+  }
+  if (!/^[^/\s]+\/[^#\s]+#\d+$/.test(String(manifest?.docsImpactIssue))) {
+    errors.push('manifest docsImpactIssue must be owner/repo#number');
+  }
+  if (!['mapped', 'replay'].includes(manifest?.stage)) {
+    errors.push('manifest stage must be mapped or replay');
+  }
+  if (!Array.isArray(manifest?.captures)) {
+    errors.push('manifest captures must be an array');
+  }
+  if (!Array.isArray(manifest?.blockedCaptures)) {
+    errors.push('manifest blockedCaptures must be an array');
+  }
+
+  const ids = new Set();
+  const validatedCaptures = [];
+  for (const capture of captures) {
+    if (ids.has(capture?.id)) {
+      errors.push(`capture id is duplicated: ${capture.id}`);
+    }
+    ids.add(capture?.id);
+    const validated = validateCapture({
+      root: absoluteRoot,
+      capture,
+      diff,
+      baseRef,
+      errors,
+      warnings,
+    });
+    if (validated) validatedCaptures.push(validated);
+  }
+
+  const declaredAssets = new Set();
+  for (const capture of captures) {
+    for (const candidate of [capture?.asset, capture?.mirrorAsset]) {
+      if (!candidate) continue;
+      try {
+        declaredAssets.add(normalizeRepoPath(candidate));
+      } catch {
+        // validateCapture already reports invalid repository paths.
+      }
+    }
+  }
+  for (const changedAsset of changedScreenshotPaths(diff)) {
+    if (!declaredAssets.has(changedAsset)) {
+      errors.push(`changed screenshot is not declared by the manifest: ${changedAsset}`);
+    }
+  }
+
+  for (const blocked of blockedCaptures) {
+    if (!blocked || typeof blocked !== 'object') {
+      errors.push('blockedCaptures entries must be objects');
+      continue;
+    }
+    if (
+      blocked.asset ||
+      blocked.mirrorAsset ||
+      blocked.sha256 ||
+      blocked.outputPixels
+    ) {
+      errors.push(
+        `blocked capture ${blocked.id || '<missing-id>'} must not claim asset/hash completion`,
+      );
+    }
+  }
+
+  const status = errors.length > 0
+    ? 'fail'
+    : warnings.length > 0
+      ? 'warning'
+      : captures.length > 0
+        ? 'pass'
+        : 'not_applicable';
+
+  return {
+    schemaVersion: 'docs-screenshots-check.v1',
+    status,
+    valid: errors.length === 0,
+    root: absoluteRoot,
+    baseRef,
+    captureCount: captures.length,
+    blockedCaptureCount: blockedCaptures.length,
+    validatedCaptures,
+    changedScreenshotPaths: changedScreenshotPaths(diff),
+    warnings,
+    errors,
+  };
+}
+
+function writeResult(result, output) {
+  const payload = `${JSON.stringify(result, null, 2)}\n`;
+  if (!output || output === '-') process.stdout.write(payload);
+  else fs.writeFileSync(output, payload, { mode: 0o600 });
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return 0;
+  }
+
+  const root = path.resolve(options.root);
+  let diffText = '';
+  if (options.diffFile) {
+    diffText = fs.readFileSync(options.diffFile, 'utf8');
+  } else {
+    const gitDiff = gitNameStatus(root, options.baseRef);
+    if (gitDiff.error) {
+      throw new Error(
+        `cannot determine screenshot diff against ${options.baseRef}: ${gitDiff.error}`,
+      );
+    }
+    diffText = gitDiff.text;
+  }
+
+  if (!options.manifest) {
+    const diff = parseNameStatus(diffText);
+    const changedAssets = changedScreenshotPaths(diff);
+    const result = {
+      schemaVersion: 'docs-screenshots-check.v1',
+      status: changedAssets.length > 0 ? 'fail' : 'not_applicable',
+      valid: changedAssets.length === 0,
+      root,
+      baseRef: options.baseRef,
+      captureCount: 0,
+      blockedCaptureCount: 0,
+      validatedCaptures: [],
+      changedScreenshotPaths: changedAssets,
+      warnings: [],
+      errors:
+        changedAssets.length > 0
+          ? [
+              `screenshot changes require --manifest: ${changedAssets.join(', ')}`,
+            ]
+          : [],
+    };
+    writeResult(result, options.output);
+    return result.valid ? 0 : 1;
+  }
+
+  const manifest = readManifest(options.manifest);
+  const result = validateScreenshotManifest({
+    root,
+    manifest,
+    diffText,
+    baseRef: options.baseRef,
+  });
+  writeResult(result, options.output);
+  return result.valid ? 0 : 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    writeResult(
+      {
+        schemaVersion: 'docs-screenshots-check.v1',
+        status: 'fail',
+        valid: false,
+        warnings: [],
+        errors: [error instanceof Error ? error.message : String(error)],
+      },
+      '-',
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-screenshots.test.mjs
+++ b/scripts/check-screenshots.test.mjs
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+import { validateScreenshotManifest } from './check-screenshots.mjs';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const PNG_FIXTURE = path.join(
+  REPO_ROOT,
+  'docs/user-guide/img/top-bar-controls-current.png',
+);
+
+function runGit(root, args) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function makeFixture({ alt = 'Notification center controls' } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-screenshots-check-'));
+  const requiredDoc = 'docs/user-guide/notifications.md';
+  const mirrorDoc =
+    'i18n/en/docusaurus-plugin-content-docs/current/user-guide/notifications.md';
+  const asset = 'docs/user-guide/img/notification-center-controls.png';
+  const mirrorAsset =
+    'i18n/en/docusaurus-plugin-content-docs/current/user-guide/img/notification-center-controls.png';
+  const compositionReference =
+    'docs/user-guide/img/top-bar-controls-current.png';
+
+  for (const directory of [
+    path.dirname(path.join(root, requiredDoc)),
+    path.dirname(path.join(root, mirrorDoc)),
+    path.dirname(path.join(root, asset)),
+    path.dirname(path.join(root, mirrorAsset)),
+  ]) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+  fs.copyFileSync(PNG_FIXTURE, path.join(root, compositionReference));
+  fs.writeFileSync(
+    path.join(root, requiredDoc),
+    `# 通知\n\n点击顶部通知控件可查看分类后的消息。\n\n![${alt}](./img/notification-center-controls.png)\n`,
+  );
+  fs.writeFileSync(
+    path.join(root, mirrorDoc),
+    `# Notifications\n\nUse the top-bar control to open categorized notifications.\n\n![${alt}](./img/notification-center-controls.png)\n`,
+  );
+  runGit(root, ['init', '-b', 'main']);
+  runGit(root, ['config', 'user.email', 'docs-screenshots@example.invalid']);
+  runGit(root, ['config', 'user.name', 'Docs Screenshot Test']);
+  runGit(root, ['add', '.']);
+  runGit(root, ['commit', '-m', 'baseline composition and docs']);
+  fs.copyFileSync(PNG_FIXTURE, path.join(root, asset));
+  fs.copyFileSync(PNG_FIXTURE, path.join(root, mirrorAsset));
+
+  const capture = {
+    id: 'grp-notifications-controls',
+    groupId: 'grp-notifications',
+    action: 'add',
+    requiredDoc,
+    mirrorDoc,
+    asset,
+    mirrorAsset,
+    sourceRepo: 'linancn/tiangong-lca-next',
+    sourceCommit: 'a'.repeat(40),
+    sourcePullRequests: ['linancn/tiangong-lca-next#1'],
+    captureMode: 'local-candidate',
+    routePattern: '/notifications',
+    uiState: 'notification center open',
+    locale: 'en-US',
+    viewport: { width: 1440, height: 900, deviceScaleFactor: 2 },
+    compositionClass: 'control-strip',
+    compositionReference,
+    outputPixels: { width: 536, height: 216 },
+    aspectRatio: 536 / 216,
+    dpi: 144,
+    callouts: [],
+    privacyReview: {
+      syntheticOrPublicData: true,
+      opaqueMasksApplied: [],
+      secretsAbsent: true,
+      reviewed: true,
+    },
+    sha256: crypto
+      .createHash('sha256')
+      .update(fs.readFileSync(path.join(root, asset)))
+      .digest('hex'),
+  };
+  const manifest = {
+    schemaVersion: 'docs-impact-visual-result.v1',
+    docsImpactIssue: 'tiangong-lca/workspace#1',
+    stage: 'mapped',
+    captures: [capture],
+    blockedCaptures: [],
+  };
+  const diffText = `A\t${asset}\nA\t${mirrorAsset}\n`;
+
+  return { root, capture, manifest, diffText, baseRef: 'HEAD' };
+}
+
+test('accepts bilingual mirrored assets with nearby prose and no fixed figure phrase', () => {
+  const fixture = makeFixture();
+  try {
+    const result = validateScreenshotManifest(fixture);
+    assert.equal(result.valid, true, result.errors.join('\n'));
+    assert.equal(result.status, 'pass');
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a missing English mirror asset', () => {
+  const fixture = makeFixture();
+  try {
+    fs.unlinkSync(path.join(fixture.root, fixture.capture.mirrorAsset));
+    const result = validateScreenshotManifest(fixture);
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((error) => error.includes('mirrorAsset')));
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects generic alt text', () => {
+  const fixture = makeFixture({ alt: 'image' });
+  try {
+    const result = validateScreenshotManifest(fixture);
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((error) => error.includes('generic alt text')));
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a changed screenshot that is not declared by the manifest', () => {
+  const fixture = makeFixture();
+  try {
+    fixture.diffText +=
+      'A\tdocs/user-guide/img/undeclared-screenshot.png\n';
+    const result = validateScreenshotManifest(fixture);
+    assert.equal(result.valid, false);
+    assert.ok(
+      result.errors.some((error) =>
+        error.includes('changed screenshot is not declared'),
+      ),
+    );
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects add when the selected diff does not contain both assets', () => {
+  const fixture = makeFixture();
+  try {
+    const result = validateScreenshotManifest({
+      ...fixture,
+      diffText: '',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(
+      result.errors.some((error) =>
+        error.includes('add requires both mirror assets'),
+      ),
+    );
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('requires nearby explanatory prose in each language page', () => {
+  const fixture = makeFixture();
+  try {
+    fs.writeFileSync(
+      path.join(fixture.root, fixture.capture.mirrorDoc),
+      '# Notifications\n\n![Notification center controls](./img/notification-center-controls.png)\n',
+    );
+    const result = validateScreenshotManifest(fixture);
+    assert.equal(result.valid, false);
+    assert.ok(
+      result.errors.some((error) =>
+        error.includes('mirrorDoc has no nearby explanatory prose'),
+      ),
+    );
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a replace whose binary hash did not change', () => {
+  const fixture = makeFixture();
+  try {
+    fixture.capture.action = 'replace';
+    delete fixture.capture.compositionReference;
+    runGit(fixture.root, [
+      'add',
+      fixture.capture.asset,
+      fixture.capture.mirrorAsset,
+    ]);
+    runGit(fixture.root, ['commit', '-m', 'baseline assets']);
+    const diffText = `M\t${fixture.capture.asset}\nM\t${fixture.capture.mirrorAsset}\n`;
+    const result = validateScreenshotManifest({
+      ...fixture,
+      diffText,
+      baseRef: 'HEAD',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((error) => error.includes('did not change')));
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -4,7 +4,7 @@ Public documentation index for TianGong LCA users, integrators, and AI retrieval
 
 Source site: https://docs.tiangong.earth
 Source repository: https://github.com/linancn/tiangong-lca-next-docs
-Source commit: e3841430456529866f51c0ce98ba4582f7af226b
+Source commit: 471aa2bd61fe7de09b78f60a11305771e265d7d6
 Publication scope: public Docusaurus docs only. Internal agent, plan, incident, TODO, and governance execution records are excluded.
 
 ## English (en)


### PR DESCRIPTION
## Summary

- add a screenshot manifest validator for add, replace, and reuse actions
- enforce page-local Chinese/English mirror assets, identical bytes, meaningful alt text, and nearby explanatory prose in each language page
- validate PNG identity, dimensions, 144-DPI metadata, source provenance, privacy review, and add/replace aspect-ratio rules against the base commit
- reject undeclared screenshot changes and fail closed when declared add/replace evidence is absent
- document the asset placement and validation workflow in both languages

The prose contract intentionally does not require a fixed caption or a phrase such as “shown below”; the image only needs a clear nearby relationship to the changed content.

## Validation

- screenshot validator test suite: 7 tests passed
- empty-diff validator smoke
- llms index freshness and publication-scope checks
- Markdown lint and TypeScript typecheck
- successful Docusaurus production build for `zh-CN` and `en`
- strict staged Docpact validation and lint

Closes #110
Refs tiangong-lca/workspace#459
