### PR TITLE
Publish tidas v0.1.3 installation guidance

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-27"
-lastReviewedCommit: "073189be1babc2cf9d75ae35c44a24ef44bf90fa"
-lastReviewedNote: "Reviewed for Issue #112: bilingual public-content and generated-publication rules still cover the TIDAS CLI workflow change without a routing or ownership change."
+lastReviewedAt: "2026-08-01"
+lastReviewedCommit: "48d2591bfe0f323fba873b81a8fcdc84c21b27e6"
+lastReviewedNote: "Reviewed for Issue #115: bilingual public-content and generated-publication rules cover the tidas v0.1.3 rollout without a routing or ownership change."
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: 073189be1babc2cf9d75ae35c44a24ef44bf90fa
-lastReviewedNote: "Reviewed for Issue #112: the bilingual public-doc, validation, publication, and workspace-integration boundaries remain current for native tidas CLI guidance."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 48d2591bfe0f323fba873b81a8fcdc84c21b27e6
+lastReviewedNote: "Reviewed for Issue #115: the bilingual public-doc, validation, publication, and workspace-integration boundaries remain current for the tidas v0.1.3 rollout."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ checkPaths:
   - scripts/check-screenshots.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: 073189be1babc2cf9d75ae35c44a24ef44bf90fa
-lastReviewedNote: "Updated for Issue #112: clean-checkout dependency setup now matches the repository's current lockfile-free package policy."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 48d2591bfe0f323fba873b81a8fcdc84c21b27e6
+lastReviewedNote: "Reviewed for Issue #115: the tidas v0.1.3 public-doc update uses the current lockfile-free build and publication workflow."
 related:
   - AGENTS.md
   - docs/agents/repo-validation.md

--- a/TODO.docs-system-gaps.md
+++ b/TODO.docs-system-gaps.md
@@ -21,9 +21,9 @@ checkPaths:
   - scripts/check-screenshots.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: 073189be1babc2cf9d75ae35c44a24ef44bf90fa
-lastReviewedNote: "Reviewed for Issue #112: native tidas package guidance and lockfile-free setup are fully updated, with no remaining product/docs drift backlog item."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 48d2591bfe0f323fba873b81a8fcdc84c21b27e6
+lastReviewedNote: "Reviewed for Issue #115: native tidas v0.1.3 guidance is fully updated, with no remaining product/docs drift backlog item."
 related:
   - AGENTS.md
   - README.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -34,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: 073189be1babc2cf9d75ae35c44a24ef44bf90fa
-lastReviewedNote: "Reviewed for Issue #112: next-docs still owns bilingual public CLI guidance and generated publication assets, while executable behavior remains external."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 48d2591bfe0f323fba873b81a8fcdc84c21b27e6
+lastReviewedNote: "Reviewed for Issue #115: next-docs still owns bilingual tidas v0.1.3 CLI guidance and generated publication assets, while executable behavior remains external."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -34,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: 073189be1babc2cf9d75ae35c44a24ef44bf90fa
-lastReviewedNote: "Reviewed for Issue #112: the existing bilingual, llms.txt, publication-scope, build, link, and docpact proof requirements remain current."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 48d2591bfe0f323fba873b81a8fcdc84c21b27e6
+lastReviewedNote: "Reviewed for Issue #115: the existing bilingual, llms.txt, publication-scope, build, link, and docpact proof requirements remain current for tidas v0.1.3."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/dev/dev-env.md
+++ b/docs/dev/dev-env.md
@@ -23,9 +23,9 @@ checkPaths:
   - scripts/check-screenshots.test.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: 073189be1babc2cf9d75ae35c44a24ef44bf90fa
-lastReviewedNote: "Updated for Issue #112: clean-checkout dependency setup now uses the repository's current lockfile-free installation command."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 48d2591bfe0f323fba873b81a8fcdc84c21b27e6
+lastReviewedNote: "Reviewed for Issue #115: the tidas v0.1.3 public-doc update uses the current lockfile-free installation and publication checks."
 related:
   - i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
   - docs/agents/repo-validation.md

--- a/docs/integration/cli.md
+++ b/docs/integration/cli.md
@@ -2,7 +2,7 @@
 
 命令行工作流涉及两个独立工具：
 
-- [`tidas`](https://github.com/tiangong-lca/tidas-tools/releases/tag/v0.1.1) 是已发布的原生
+- [`tidas`](https://github.com/tiangong-lca/tidas-tools/releases/tag/v0.1.3) 是已发布的原生
   Rust 可执行程序，用于本地 TIDAS/eILCD 转换、外部 LCA 格式导入、包校验、数据库导出和确定性发布打包。
 - `tiangong-lca` 是 npm 发布的 TianGong LCA 平台客户端，用于远程查询、草稿写入、审查和其他
   API 工作流。
@@ -10,7 +10,7 @@
 这两个命令不是别名。需要处理本地数据包时直接调用 `tidas`；不要假定 `tiangong-lca` 会在内部
 调用它。
 
-## 安装 `tidas` 0.1.1
+## 安装 `tidas` 0.1.3
 
 预编译归档是普通用户的首选安装渠道，不需要 Rust、Python、Java 或 Node.js。安装器会下载
 固定版本归档和对应的 `.sha256` 文件，校验后再安装。
@@ -19,8 +19,8 @@
 
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSLO \
-  https://github.com/tiangong-lca/tidas-tools/releases/download/v0.1.1/install.sh
-sh install.sh --version 0.1.1 --prefix "$HOME/.local"
+  https://github.com/tiangong-lca/tidas-tools/releases/download/v0.1.3/install.sh
+sh install.sh --version 0.1.3 --prefix "$HOME/.local"
 "$HOME/.local/bin/tidas" --version
 ```
 
@@ -30,9 +30,9 @@ sh install.sh --version 0.1.1 --prefix "$HOME/.local"
 
 ```powershell
 Invoke-WebRequest `
-  https://github.com/tiangong-lca/tidas-tools/releases/download/v0.1.1/install.ps1 `
+  https://github.com/tiangong-lca/tidas-tools/releases/download/v0.1.3/install.ps1 `
   -OutFile install.ps1
-.\install.ps1 -Version 0.1.1
+.\install.ps1 -Version 0.1.3
 & "$env:LOCALAPPDATA\Programs\tidas\bin\tidas.exe" --version
 ```
 
@@ -42,13 +42,13 @@ Invoke-WebRequest `
 
 | 平台 | 发布归档 |
 | --- | --- |
-| Linux x86_64 | `tidas-v0.1.1-x86_64-unknown-linux-gnu.tar.gz` |
-| Linux ARM64 | `tidas-v0.1.1-aarch64-unknown-linux-gnu.tar.gz` |
-| macOS Intel | `tidas-v0.1.1-x86_64-apple-darwin.tar.gz` |
-| macOS Apple Silicon | `tidas-v0.1.1-aarch64-apple-darwin.tar.gz` |
-| Windows x86_64 | `tidas-v0.1.1-x86_64-pc-windows-msvc.zip` |
+| Linux x86_64 | `tidas-v0.1.3-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux ARM64 | `tidas-v0.1.3-aarch64-unknown-linux-gnu.tar.gz` |
+| macOS Intel | `tidas-v0.1.3-x86_64-apple-darwin.tar.gz` |
+| macOS Apple Silicon | `tidas-v0.1.3-aarch64-apple-darwin.tar.gz` |
+| Windows x86_64 | `tidas-v0.1.3-x86_64-pc-windows-msvc.zip` |
 
-每个归档在 [v0.1.1 Release](https://github.com/tiangong-lca/tidas-tools/releases/tag/v0.1.1)
+每个归档在 [v0.1.3 Release](https://github.com/tiangong-lca/tidas-tools/releases/tag/v0.1.3)
 中都有 SHA-256 sidecar 和 SPDX SBOM。Windows ARM64 不在当前支持矩阵内。Release 也提供
 Homebrew formula 与 Winget manifest 文件，但这些文件的存在不表示它们已经发布到外部 tap
 或 Winget Community 仓库。
@@ -58,7 +58,7 @@ Homebrew formula 与 Winget manifest 文件，但这些文件的存在不表示�
 已经安装 Rust 1.88+ 以及平台 libxml2/libxslt 开发依赖的开发者也可使用：
 
 ```bash
-cargo install tidas --version 0.1.1 --locked
+cargo install tidas --version 0.1.3 --locked
 tidas --version
 tidas version --format json
 ```

--- a/docs/openapi/tidas-package-import.md
+++ b/docs/openapi/tidas-package-import.md
@@ -53,7 +53,7 @@ https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1
 ## 上传前使用 `tidas` 做本地预检
 
 自动化客户端可以在调用 API 前使用已发布的 Rust
-[`tidas` 0.1.1 CLI](/integration/cli#安装-tidas-011) 检查待上传包。先把 ZIP 解压到临时目录，
+[`tidas` 0.1.3 CLI](/integration/cli#安装-tidas-013) 检查待上传包。先把 ZIP 解压到临时目录，
 再执行：
 
 ```bash

--- a/docs/user-guide/tidas-zip-workflows.md
+++ b/docs/user-guide/tidas-zip-workflows.md
@@ -11,7 +11,7 @@ description: 说明顶部全局入口中的 TIDAS ZIP 导入、导出，以及�
 本文主要说明网页端的交互流程。
 
 需要在上传前从 EcoSpold、openLCA、SimaPro 或 ILCD/eILCD 准备并校验 TIDAS 包时，请使用已发布
-的 Rust [`tidas` 0.1.1 命令行工具](/integration/cli#安装-tidas-011)。它是独立的本地包工具，
+的 Rust [`tidas` 0.1.3 命令行工具](/integration/cli#安装-tidas-013)。它是独立的本地包工具，
 不是网页端或 `tiangong-lca` 平台客户端的别名。
 
 ## 入口位置

--- a/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dev/dev-env.md
@@ -23,9 +23,9 @@ checkPaths:
   - scripts/check-screenshots.test.mjs
   - context7.json
   - static/llms.txt
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: 073189be1babc2cf9d75ae35c44a24ef44bf90fa
-lastReviewedNote: "Updated for Issue #112: clean-checkout dependency setup now uses the repository's current lockfile-free installation command."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 48d2591bfe0f323fba873b81a8fcdc84c21b27e6
+lastReviewedNote: "Reviewed for Issue #115: the tidas v0.1.3 public-doc update uses the current lockfile-free installation and publication checks."
 related:
   - docs/dev/dev-env.md
   - docs/agents/repo-validation.md

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
@@ -2,7 +2,7 @@
 
 Command-line workflows use two independent tools:
 
-- [`tidas`](https://github.com/tiangong-lca/tidas-tools/releases/tag/v0.1.1) is the
+- [`tidas`](https://github.com/tiangong-lca/tidas-tools/releases/tag/v0.1.3) is the
   released native Rust executable for local TIDAS/eILCD conversion, external LCA
   import, package validation, database export, and deterministic release packaging.
 - `tiangong-lca` is the npm-distributed TianGong LCA platform client for remote
@@ -11,7 +11,7 @@ Command-line workflows use two independent tools:
 The commands are not aliases. Invoke `tidas` directly for local package work; do
 not assume that `tiangong-lca` invokes it internally.
 
-## Install `tidas` 0.1.1
+## Install `tidas` 0.1.3
 
 Prebuilt archives are the preferred end-user channel and require no Rust,
 Python, Java, or Node.js runtime. The installers download an immutable archive
@@ -21,8 +21,8 @@ and its `.sha256` file and verify it before installation.
 
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSLO \
-  https://github.com/tiangong-lca/tidas-tools/releases/download/v0.1.1/install.sh
-sh install.sh --version 0.1.1 --prefix "$HOME/.local"
+  https://github.com/tiangong-lca/tidas-tools/releases/download/v0.1.3/install.sh
+sh install.sh --version 0.1.3 --prefix "$HOME/.local"
 "$HOME/.local/bin/tidas" --version
 ```
 
@@ -32,9 +32,9 @@ Add `$HOME/.local/bin` to `PATH` if your shell does not already include it.
 
 ```powershell
 Invoke-WebRequest `
-  https://github.com/tiangong-lca/tidas-tools/releases/download/v0.1.1/install.ps1 `
+  https://github.com/tiangong-lca/tidas-tools/releases/download/v0.1.3/install.ps1 `
   -OutFile install.ps1
-.\install.ps1 -Version 0.1.1
+.\install.ps1 -Version 0.1.3
 & "$env:LOCALAPPDATA\Programs\tidas\bin\tidas.exe" --version
 ```
 
@@ -44,14 +44,14 @@ If prompted, add that `bin` directory to `PATH`.
 
 | Platform | Release archive |
 | --- | --- |
-| Linux x86_64 | `tidas-v0.1.1-x86_64-unknown-linux-gnu.tar.gz` |
-| Linux ARM64 | `tidas-v0.1.1-aarch64-unknown-linux-gnu.tar.gz` |
-| macOS Intel | `tidas-v0.1.1-x86_64-apple-darwin.tar.gz` |
-| macOS Apple Silicon | `tidas-v0.1.1-aarch64-apple-darwin.tar.gz` |
-| Windows x86_64 | `tidas-v0.1.1-x86_64-pc-windows-msvc.zip` |
+| Linux x86_64 | `tidas-v0.1.3-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux ARM64 | `tidas-v0.1.3-aarch64-unknown-linux-gnu.tar.gz` |
+| macOS Intel | `tidas-v0.1.3-x86_64-apple-darwin.tar.gz` |
+| macOS Apple Silicon | `tidas-v0.1.3-aarch64-apple-darwin.tar.gz` |
+| Windows x86_64 | `tidas-v0.1.3-x86_64-pc-windows-msvc.zip` |
 
 Every archive in the
-[v0.1.1 release](https://github.com/tiangong-lca/tidas-tools/releases/tag/v0.1.1)
+[v0.1.3 release](https://github.com/tiangong-lca/tidas-tools/releases/tag/v0.1.3)
 has a SHA-256 sidecar and an SPDX SBOM. Windows ARM64 is outside the current
 support matrix. The release also contains Homebrew formula and Winget manifest
 files; their presence does not mean they have been submitted to an external tap
@@ -63,7 +63,7 @@ Developers with Rust 1.88+ and the platform libxml2/libxslt development
 dependencies can install from source:
 
 ```bash
-cargo install tidas --version 0.1.1 --locked
+cargo install tidas --version 0.1.3 --locked
 tidas --version
 tidas version --format json
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md
@@ -56,7 +56,7 @@ It is a good idea to send `X-Idempotency-Key` with `prepare_upload` and
 ## Preflight locally with `tidas`
 
 Automation clients can check a package with the released Rust
-[`tidas` 0.1.1 CLI](/en/integration/cli#install-tidas-011) before calling the
+[`tidas` 0.1.3 CLI](/en/integration/cli#install-tidas-013) before calling the
 API. Extract the ZIP into a temporary directory, then run:
 
 ```bash

--- a/i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/user-guide/tidas-zip-workflows.md
@@ -11,7 +11,7 @@ If you only need the API flow, use [TIDAS Package Import API](/en/docs/openapi/t
 This page focuses on the web UI workflow.
 
 Use the released Rust
-[`tidas` 0.1.1 CLI](/en/integration/cli#install-tidas-011) when you need to
+[`tidas` 0.1.3 CLI](/en/integration/cli#install-tidas-013) when you need to
 prepare and validate a TIDAS package from EcoSpold, openLCA, SimaPro, or
 ILCD/eILCD before upload. It is an independent local package tool, not an alias
 for the web UI or the `tiangong-lca` platform client.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -4,7 +4,7 @@ Public documentation index for TianGong LCA users, integrators, and AI retrieval
 
 Source site: https://docs.tiangong.earth
 Source repository: https://github.com/linancn/tiangong-lca-next-docs
-Source commit: a2405df0a219a5b861f8a80a91be8f6224092f92
+Source commit: 48d2591bfe0f323fba873b81a8fcdc84c21b27e6
 Publication scope: public Docusaurus docs only. Internal agent, plan, incident, TODO, and governance execution records are excluded.
 
 ## English (en)


### PR DESCRIPTION
## Summary
- update bilingual tidas installation guidance and release asset names to v0.1.3
- update linked import and ZIP workflow pages to the new section anchors
- regenerate static/llms.txt and review the publication/governance surfaces

## Validation
- markdown lint and TypeScript typecheck
- bilingual Docusaurus production build
- llms.txt, publication-scope, and screenshot checks
- docpact strict config validation and enforced lint

Closes #115

Parent: tiangong-lca/workspace#540