### PR TITLE
文档影响：补充 issue 558 CLI 分类校验说明

### DIFF
--- a/docs/integration/cli.md
+++ b/docs/integration/cli.md
@@ -212,6 +212,7 @@ tiangong-lca publish run --input ./publish-request.json --dry-run --json
 - 校验通过的数据仍走快速路径；
 - 校验失败的数据会尽量返回更可操作的字段路径、错误码和消息；
 - `--commit` 写入前仍会拦截 schema-invalid 行，并把失败明细写入输出目录中的 `failures.jsonl` 或校验报告。
+- TIDAS schema 中的 `common:classification` / `common:category` 可停在自然分类深度；不要为了补齐层级添加空的下级分类。超过最大层级、重复层级或无效分类值仍会被拦截。
 - 批量写入草稿时，`process save-draft --commit` 建议同时传入 `--target-user-id`。CLI 会校验当前认证会话和可见草稿所有者，写入后仍以回读结果证明最终 owner 与 payload。
 - `dataset classification apply --type location` 在 `target_path` 明确指向 schema 派生的 location 字段时，可以创建缺失的父对象和目标字段；模糊路径或非 location 字段仍会被阻止。
 - `dataset evidence-search run` 会在 `outputs/` 中写出检索计划、归一化结果、报告，以及在证据不足或只有部分时写出证据声明 JSON。

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
@@ -221,6 +221,7 @@ That means:
 - data that passes validation still uses the fast path;
 - invalid data should return more actionable field paths, issue codes, and messages;
 - before any `--commit` write, schema-invalid rows are blocked and recorded in `failures.jsonl` or the validation report under the output directory.
+- TIDAS schema `common:classification` / `common:category` paths may stop at their natural category depth; do not add empty lower-level classes just to fill the hierarchy. Over-deep paths, duplicate levels, or invalid values are still blocked.
 - For batch draft writes, pass `--target-user-id` with `process save-draft --commit`. The CLI verifies the current auth session and any visible draft owner before writing, while readback verification still proves the final owner and payload.
 - `dataset classification apply --type location` can create the missing parent object and target field when `target_path` explicitly points at a schema-derived location field. Ambiguous paths or non-location fields still block.
 - `dataset evidence-search run` writes the search plan, normalized results, report, and, when evidence is insufficient or partial, an evidence declaration JSON under `outputs/`.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -4,7 +4,7 @@ Public documentation index for TianGong LCA users, integrators, and AI retrieval
 
 Source site: https://docs.tiangong.earth
 Source repository: https://github.com/linancn/tiangong-lca-next-docs
-Source commit: 2b4909c26a05711b88d046485aec2c77216c30a1
+Source commit: 731c451892596c08764bda9a366380d59aba7887
 Publication scope: public Docusaurus docs only. Internal agent, plan, incident, TODO, and governance execution records are excluded.
 
 ## English (en)


### PR DESCRIPTION
## 摘要

- Replay issue `tiangong-lca/workspace#558` after governance PR `tiangong-lca/workspace#560` mapped the original TIDAS schema asset rows.
- 更新 `docs/integration/cli.md` 与英文镜像，说明 CLI 本地 TIDAS schema 校验允许分类路径停在自然分类深度。
- 保留 OpenAPI TIDAS package import 文档不变，因为 mapped docs PR #117 已覆盖同一 shallow-classification contract。
- 重新生成 `static/llms.txt`。

## Pre-change decision summary

<!-- docs-impact-pre-change-summary:start -->
## Coverage group plan

| groupId | groupName | targetDocs | sourcePullRequests | groupIntent |
|---|---|---|---|---|
| tidas-tools-shallow-classification | TIDAS Tools schema assets already covered by import docs | docs/openapi/tidas-package-import.md + English mirror | tiangong-lca/tidas-tools#101 | Recheck the newly governed TIDAS Tools bundled schema assets against the TIDAS package import API docs after mapped PR #117 already documented the same shallow-classification contract from SDK schema rows. |
| cli-shallow-classification | CLI bundled schema validation accepts natural classification depth | docs/integration/cli.md + English mirror | tiangong-lca/tiangong-cli#148 | Update CLI integration guidance because the CLI package ships the same relaxed TIDAS schema assets and the CLI page does not yet state the shallow classification behavior. |

Replay rematch summary: original 11 unmapped rows against governance merge `81905dcd7aa3879c9e0eb4f9a5f5c5520156b67a` produced 10 mapped rows, 1 explicit exclude, and 0 remaining unmapped rows. The excluded row is `tiangong-lca-edge-functions/scripts/deploy-function.cjs` under `user-docs-exclude-repo-maintenance-and-local-tooling`; it is not a public docs ledger row.

Dependency bootstrap: next-docs dependency bootstrap: npm install. Source Node-backed commands: not needed; source evidence review used detached worktree files and git diffs only.

## Coverage ledger

| groupId | groupName | requiredDoc | ruleId | sourcePullRequest | terminal | reason |
|---|---|---|---|---|---|---|
| tidas-tools-shallow-classification | TIDAS Tools schema assets already covered by import docs | docs/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-tools#101 | reviewed-no-change | The Chinese import API page already states that classification fields may stop at natural category depth and that over-deep, duplicate, or invalid category values still fail. That statement was added by mapped docs PR #117 for the same schema contract. |
| tidas-tools-shallow-classification | TIDAS Tools schema assets already covered by import docs | i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md | user-docs-openapi-tidas-package-import | tiangong-lca/tidas-tools#101 | reviewed-no-change | The English import API mirror already contains the same shallow-classification guidance and validation limits from mapped docs PR #117. |
| cli-shallow-classification | CLI bundled schema validation accepts natural classification depth | docs/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#148 | update-docs | The CLI page explains TIDAS schema validation but does not yet tell users that common classification/category paths may stop at their natural depth. |
| cli-shallow-classification | CLI bundled schema validation accepts natural classification depth | i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md | user-docs-cli-public-usage | tiangong-lca/tiangong-cli#148 | update-docs | The English CLI mirror has the same missing user-facing validation note. |

### Decision group: tidas-tools-shallow-classification - TIDAS Tools schema assets already covered by import docs

- groupId: tidas-tools-shallow-classification
- groupName: TIDAS Tools schema assets already covered by import docs
- grouping basis: same source PR, same TIDAS Tools bundled schema family, same required OpenAPI import docs, and same shallow-classification contract already documented from SDK schema rows.
- covered ledger keys:
  - docs/openapi/tidas-package-import.md|user-docs-openapi-tidas-package-import|tiangong-lca/tidas-tools#101
  - i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md|user-docs-openapi-tidas-package-import|tiangong-lca/tidas-tools#101
- scanner input: replay rematch rows for `tidas-tools/src/tidas_tools/tidas/schemas/tidas_contacts.json`, `tidas_flows.json`, `tidas_lciamethods.json`, `tidas_lifecyclemodels.json`, and `tidas_processes.json`; rule `user-docs-openapi-tidas-package-import`; required docs `docs/openapi/tidas-package-import.md` and English mirror.
- per-source evidence: source PR `tiangong-lca/tidas-tools#101`; source version `dd8b154d72f7e9b199e36d78c494ec89b09ed66c`; source worktree `/Users/foreveryoung/tiangong/automation-worktree1/docs-impact/issue-558/source-evidence/tidas-tools/pr-101`; code context reviewed in the five schema files and the validator/converter schema asset family; checked diff `077f545bc86853a747d6bdbb69ed9cfc95b6b5c6..dd8b154d72f7e9b199e36d78c494ec89b09ed66c`; representative `tidas_processes.json` diff replaces per-level `contains` constraints with `maxItems` plus `additionalItems: false`.
- combined business impact: TIDAS Tools validation accepts classification arrays that stop at the natural category depth instead of requiring empty lower levels, while still enforcing maximum depth and uniqueness through the schema. This affects package validation/import semantics, not UI layout.
- user-visible impact: yes
- target: next-docs page review only; no file edit for this group.
- target file: docs/openapi/tidas-package-import.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/openapi/tidas-package-import.md
- target document structure reviewed: full Chinese page and English mirror reviewed, including the validation failure example, Process Dataset Field Compatibility section, CAS validation section, and implementation notes.
- document purpose reviewed: the page documents external TIDAS ZIP import API usage, local `tidas validate` preflight, server-side validation reports, and field compatibility guidance for API clients.
- page structure map: H1 TIDAS data package import API; H2 Typical Use Cases; H2 Authentication and Base URL; H2 Flow Overview; H2 local `tidas` preflight; H2 Prepare Upload; H2 Upload ZIP; H2 Enqueue; H2 Poll Job Status; H2 Import Report Semantics; H2 Validation Failure Example; H3 Process Dataset Field Compatibility; H3 CAS Number Validation; H2 Implementation Notes.
- relevant existing content reviewed: the Process Dataset Field Compatibility section already contains bullets saying classification fields may stop at natural category depth, users should not add empty lower-level classes, and maximum depth, one value per level, and valid category values still apply.
- affected existing claims: correct and current; mapped docs PR #117 already added the public behavior that this replay group would otherwise need.
- existing-claim reconciliation: update existing content is unnecessary because the same user-facing claim is already accurate in both languages.
- edit operation: update-existing
- why not only update existing content: not applicable; no content change selected.
- selected edit target: not applicable; existing Process Dataset Field Compatibility bullets already cover the impact.
- new content type: field explanation
- placement candidates: existing Process Dataset Field Compatibility section accepted as already correct; a new OpenAPI section rejected because it would duplicate an existing field-compatibility note; CLI page rejected for this group because TIDAS Tools package validation is already represented by the import API page.
- placement decision: not applicable
- selected placement: not applicable
- heading path: TIDAS data package import API > Validation Failure Example > Process Dataset Field Compatibility
- insertion point: not applicable
- mirror placement: `Command-Line Integration > `tiangong-lca` validation and failure reports`
- reader block boundary: existing classification bullets remain inside the Process Dataset Field Compatibility bullet list; no title or media block is split.
- placement rationale: no safe new placement is needed because the current section already owns exactly this schema compatibility claim.
- rejected placements: new OpenAPI heading, CLI integration page, and implementation notes.
- mirror semantic equivalence: Chinese and English pages already carry equivalent shallow-classification wording.
- missing required doc decision: not applicable
- missing required doc rationale: not applicable
- navigation decision: not applicable
- visual need: not-needed
- visual action: none
- visual rationale: schema validation behavior is text/API/CLI contract behavior and has no product UI state to capture.
- visual target: not applicable
- existing visual review: no relevant screenshot assets on this API page; none needed.
- screenshot ids: none
- visual privacy plan: not applicable
- visual blocker: none
- access validation: not applicable
- visual validation plan: no capture; run visual gate in advisory mode only if assets are staged, otherwise not applicable.
- action: noop
- reason: the required OpenAPI import docs and English mirror already contain the exact shallow-classification guidance from mapped docs PR #117, so replay should not duplicate that content.
- validation plan: run `validate-pre-change-decision.rb --stage replay`; if the mixed ledger passes, edit only the CLI docs group, then run staged/head placement and visual validation plus next-docs preflight commands.
- post-change placement check: not applicable for this group because no public docs body change is selected.

### Decision group: cli-shallow-classification - CLI bundled schema validation accepts natural classification depth

- groupId: cli-shallow-classification
- groupName: CLI bundled schema validation accepts natural classification depth
- grouping basis: same source PR, same CLI bundled schema asset family, same required CLI integration docs, and one shared validation behavior exposed through CLI local validation/write gates.
- covered ledger keys:
  - docs/integration/cli.md|user-docs-cli-public-usage|tiangong-lca/tiangong-cli#148
  - i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md|user-docs-cli-public-usage|tiangong-lca/tiangong-cli#148
- scanner input: replay rematch rows for `tiangong-lca-cli/assets/tidas-schemas/tidas_contacts.json`, `tidas_flows.json`, `tidas_lciamethods.json`, `tidas_lifecyclemodels.json`, and `tidas_processes.json`; rule `user-docs-cli-public-usage`; required docs `docs/integration/cli.md` and English mirror.
- per-source evidence: source PR `tiangong-lca/tiangong-cli#148`; source version `423acffe4d066bcadc81398f6b6e0ab670d2657b`; source worktree `/Users/foreveryoung/tiangong/automation-worktree1/docs-impact/issue-558/source-evidence/tiangong-lca-cli/pr-148`; code context reviewed in `assets/tidas-schemas/*.json`, `package.json`, `src/lib/dataset-classification.ts`, and `src/cli.ts`; checked diff `1e5b2266b381571900534cff03a01b5d1f7d37bf..423acffe4d066bcadc81398f6b6e0ab670d2657b` for the bundled schema assets and package version; `src/lib/dataset-classification.ts` resolves bundled schemas from `assets/tidas-schemas`, and `src/cli.ts` exposes public dataset classification/validate commands.
- combined business impact: the CLI package ships the relaxed TIDAS schema assets used by local validation/classification workflows, so CLI users can submit naturally shallow classification paths without padding empty lower levels; invalid over-deep, duplicate-level, or invalid-category paths remain blocked.
- user-visible impact: yes
- target: next-docs CLI integration page.
- target file: docs/integration/cli.md
- mirror file: i18n/en/docusaurus-plugin-content-docs/current/integration/cli.md
- target document structure reviewed: full Chinese page and English mirror reviewed, including install sections, `tidas` package workflows, `tiangong-lca` install/run, environment variables, common commands, automation gates, and `tiangong-lca` validation/failure report section.
- document purpose reviewed: the page orients users to the separate native `tidas` executable and npm `tiangong-lca` CLI, then documents installation, common commands, validation gates, and how to interpret CLI machine-readable reports.
- page structure map: H1 command-line integration; H2 install `tidas` 0.1.3; H3 Linux/macOS; H3 Windows PowerShell; H3 prebuilt platforms; H3 crates.io; H2 `tidas` package workflows; H3 external import to TIDAS; H3 TIDAS/eILCD conversion; H3 reports and exit codes; H2 install and run `tiangong-lca`; H2 environment variables; H2 common commands; H2 automation gates; H2 `tiangong-lca` validation and failure reports.
- relevant existing content reviewed: the CLI validation section already says dataset/process/lifecyclemodel commands run local TIDAS schema validation, fast failures fall back to deeper SDK validation, schema-invalid rows are blocked before commit, and location classification apply can create missing parent/target fields for explicit location paths.
- affected existing claims: partial; the section correctly describes validation gates but omits the updated classification-depth acceptance.
- existing-claim reconciliation: update existing validation bullet list with one additional bilingual bullet under the existing `tiangong-lca` validation and failure reports section.
- edit operation: update-existing
- why not only update existing content: not applicable; this is an update to the existing validation section, not a new standalone feature section.
- selected edit target: add one bullet after the existing schema-invalid blocking bullet and before the target-user-id / location classification bullets in both language files.
- new content type: field explanation
- placement candidates: existing `tiangong-lca` validation and failure reports bullet list accepted; common commands rejected because the change is validation semantics rather than command inventory; automation gates rejected because the behavior applies to validation/write gates generally, not only pre-publish quality gates; OpenAPI page rejected because this group is CLI-specific.
- placement decision: existing heading
- selected placement: `# 命令行集成 > ## tiangong-lca 校验与失败报告` and `# Command-Line Integration > ## tiangong-lca validation and failure reports`.
- heading path: 命令行集成 > `tiangong-lca` 校验与失败报告
- insertion point: inside section end
- mirror placement: `Command-Line Integration > `tiangong-lca` validation and failure reports`
- reader block boundary: insert inside the existing validation behavior bullet list without splitting code blocks, tables, media, or a procedure.
- placement rationale: the existing section already owns local schema validation behavior and failure interpretation, so the added bullet updates the exact reader block affected by the CLI bundled schema change.
- rejected placements: common commands list, automation gates list, TIDAS package workflows, OpenAPI import page, and a new same-level heading.
- mirror semantic equivalence: Chinese and English edits update the same CLI schema-validation claim with equivalent scope and limits under the paired validation/failure-report sections.
- missing required doc decision: not applicable
- missing required doc rationale: not applicable
- navigation decision: not applicable
- visual need: not-needed
- visual action: none
- visual rationale: this is command/schema validation text, not a UI state or screenshot-supported workflow.
- visual target: not applicable
- existing visual review: no screenshots on the target CLI page; none needed.
- screenshot ids: none
- visual privacy plan: not applicable
- visual blocker: none
- access validation: not applicable
- visual validation plan: no capture; run visual evidence gate in advisory mode with empty/no manifest if required by workflow, otherwise rely on screenshot check preflight.
- action: update-docs
- validation plan: run `validate-pre-change-decision.rb --stage replay`; edit Chinese and English CLI docs; stage only those Markdown files; run `validate-doc-placement.rb` staged and head; run `DOCS_IMPACT_VISUAL_GATE=advisory validate-visual-evidence.rb` staged/head if the command accepts no-asset text changes; run next-docs preflight scripts: `npm run docs:llms`, `npm run docs:llms:check`, `npm run docs:publication-scope:check`, `npm run lint`, `npm run typecheck`, `npm run build`, and `npm run docs:screenshots:check`; validate PR marker before recording `pr-opened`.
- post-change placement check: verify the diff touches only the declared CLI validation section in Chinese and English mirrors, adds no undeclared headings, preserves mirror alignment, and does not split a reader block.
<!-- docs-impact-pre-change-summary:end -->

## Source coverage

- Governance PR: `tiangong-lca/workspace#560` at `81905dcd7aa3879c9e0eb4f9a5f5c5520156b67a`.
- Replay rematch: `matches=10`, `excludedFiles=1`, `remainingUnmapped=0`.
- `tiangong-lca/tidas-tools#101`: reviewed `tidas-tools/src/tidas_tools/tidas/schemas/*.json`; terminal `reviewed-no-change` because OpenAPI docs already contain the mapped shallow-classification guidance.
- `tiangong-lca/tiangong-cli#148`: reviewed `tiangong-lca-cli/assets/tidas-schemas/*.json`, `package.json`, `src/lib/dataset-classification.ts`, and `src/cli.ts`; terminal `update-docs` for CLI docs.
- `linancn/tiangong-lca-edge-functions#198`: `scripts/deploy-function.cjs` rematched as explicit exclude, not a replay docs ledger row.

## Validation notes

- next-docs dependency bootstrap: npm install
- source worktree dependency bootstrap: not needed; source evidence review used detached source worktree files and git diffs only
- `validate-pre-change-decision.rb --stage replay`: pass, `gateOutcome=complete-with-doc-edits`
- `validate-doc-placement.rb` staged: pass
- `validate-visual-evidence.rb` staged, `DOCS_IMPACT_VISUAL_GATE=advisory`: pass
- `validate-doc-placement.rb` head: pass
- `validate-visual-evidence.rb` head, `DOCS_IMPACT_VISUAL_GATE=advisory`: pass
- `npm run docs:llms`: pass; `static/llms.txt` included
- `npm run docs:llms:check`: pass
- `npm run docs:publication-scope:check`: pass before and after build output existed
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run build`: pass
- `npm run docs:screenshots:check`: pass / not_applicable

PR policy: normal review PR; no warning, environment blocker, access-denied exception, or docs-scope risk requiring Draft.

Refs tiangong-lca/workspace#558

<!-- docs-impact-local-replay-mapped:v1
{
  "docsImpactIssue": "tiangong-lca/workspace#558",
  "governancePullRequest": "tiangong-lca/workspace#560",
  "governanceMergeCommit": "81905dcd7aa3879c9e0eb4f9a5f5c5520156b67a",
  "localWorker": true
}
-->
