### PR TITLE
Isolate preview reconciliation from production state

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,9 +1,9 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-23"
-lastReviewedCommit: "d4f91b9c1d5a1e37f212da006a7ee75a1555c456"
-reviewNote: "Reviewed for Issue #136: greenfield Next/Fumadocs ownership, four-locale content, Data Atlas UI, permanent output/link gates, and current publication workflows."
-lastReviewedNote: "One-time migration and obsolete screenshot validators were removed; deterministic category, route, and deny manifests remain governed build contracts."
+lastReviewedCommit: "c6f4e8d23b14e0bd33fda7a741776becbce01e01"
+reviewNote: "Reviewed for Issue #138: preview deployment validation is isolated from production Algolia and Context7 mutation; routing and rule topology remain correct."
+lastReviewedNote: "Production reconciliation retains the publication mutation boundary while preview remains validation-only."
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,9 +1,9 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-23"
-lastReviewedCommit: "c6f4e8d23b14e0bd33fda7a741776becbce01e01"
+lastReviewedCommit: "096faf0bb07928387be24423ad3198147134b460"
 reviewNote: "Reviewed for Issue #138: preview deployment validation is isolated from production Algolia and Context7 mutation; routing and rule topology remain correct."
-lastReviewedNote: "Production reconciliation retains the publication mutation boundary while preview remains validation-only."
+lastReviewedNote: "Production reconciliation retains the publication mutation boundary; preview stays noindex, canonicalizes to production, and remains validation-only."
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-23"
-lastReviewedCommit: "d06e12e96fa33939e0a0f611f903cfc5eaa3eb52"
+lastReviewedCommit: "41cad9bf624f7ae87d4961140be33747710000df"
 reviewNote: "Reviewed for Issue #138: preview deployment validation is isolated from production Algolia and Context7 mutation; routing and rule topology remain correct."
 lastReviewedNote: "Production reconciliation retains the publication mutation boundary; preview stays noindex, canonicalizes to production, and remains validation-only."
 

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-23"
-lastReviewedCommit: "096faf0bb07928387be24423ad3198147134b460"
+lastReviewedCommit: "d06e12e96fa33939e0a0f611f903cfc5eaa3eb52"
 reviewNote: "Reviewed for Issue #138: preview deployment validation is isolated from production Algolia and Context7 mutation; routing and rule topology remain correct."
 lastReviewedNote: "Production reconciliation retains the publication mutation boundary; preview stays noindex, canonicalizes to production, and remains validation-only."
 

--- a/.github/workflows/reconcile-docs.yml
+++ b/.github/workflows/reconcile-docs.yml
@@ -112,8 +112,9 @@ jobs:
 
           curl -fsSL --max-time 30 "${origin%/}/robots.txt" -o /tmp/robots.txt
           curl -fsSL --max-time 30 "${origin%/}/sitemap.xml" -o /tmp/sitemap.xml
+          canonical_origin="https://docs.tiangong.earth"
           if [ "$origin" = "https://docs.tiangong.earth" ]; then
-            if grep -qiE '^Disallow:[[:space:]]*/' /tmp/robots.txt || ! grep -qiE '^Allow:[[:space:]]*/' /tmp/robots.txt; then
+            if grep -qiE '^Disallow:[[:space:]]*/[[:space:]]*$' /tmp/robots.txt || ! grep -qiE '^Allow:[[:space:]]*/[[:space:]]*$' /tmp/robots.txt; then
               echo "::error::production robots.txt is not indexable" >&2
               exit 1
             fi
@@ -122,13 +123,17 @@ jobs:
               exit 1
             fi
           else
-            if ! grep -qiE '^Disallow:[[:space:]]*/' /tmp/robots.txt || grep -qiE '^Allow:[[:space:]]*/' /tmp/robots.txt; then
+            if ! grep -qiE '^Disallow:[[:space:]]*/[[:space:]]*$' /tmp/robots.txt || grep -qiE '^Allow:' /tmp/robots.txt; then
               echo "::error::preview robots.txt must remain non-indexable" >&2
               exit 1
             fi
           fi
-          if ! grep -Fq "<loc>${origin%/}/" /tmp/sitemap.xml || grep -FqiE 'localhost|127\.0\.0\.1' /tmp/sitemap.xml; then
-            echo "::error::sitemap.xml does not use the verified origin" >&2
+          if ! grep -Fq "<loc>${canonical_origin}/" /tmp/sitemap.xml || grep -FqiE 'localhost|127\.0\.0\.1|preview\.docs\.tiangong\.earth' /tmp/sitemap.xml; then
+            echo "::error::sitemap.xml does not use the production canonical origin" >&2
+            exit 1
+          fi
+          if grep -E '<loc>|<xhtml:link' /tmp/sitemap.xml | grep -Fvq "https://docs.tiangong.earth/"; then
+            echo "::error::sitemap.xml mixes canonical origins or contains relative URLs" >&2
             exit 1
           fi
           for locale in zh en de fr; do
@@ -143,8 +148,8 @@ jobs:
               echo "::error::preview /${locale}/docs/ must be noindex" >&2
               exit 1
             fi
-            if ! grep -Fq "<link rel=\"canonical\" href=\"${origin%/}/${locale}/docs/\"" "$page_file"; then
-              echo "::error::/${locale}/docs/ has a canonical outside the verified origin" >&2
+            if ! grep -Fq "<link rel=\"canonical\" href=\"${canonical_origin}/${locale}/docs/\"" "$page_file"; then
+              echo "::error::/${locale}/docs/ does not use the production canonical origin" >&2
               exit 1
             fi
           done

--- a/.github/workflows/reconcile-docs.yml
+++ b/.github/workflows/reconcile-docs.yml
@@ -133,9 +133,14 @@ jobs:
             exit 1
           fi
           if ! awk -v origin="${canonical_origin}/" '
-            /<loc>|<xhtml:link/ {
-              seen = 1
-              if (index($0, origin) == 0) bad = 1
+            {
+              rest = $0
+              while (match(rest, /<loc>[^<]*<\/loc>|<xhtml:link[^>]*>/)) {
+                tag = substr(rest, RSTART, RLENGTH)
+                seen = 1
+                if (index(tag, origin) == 0) bad = 1
+                rest = substr(rest, RSTART + RLENGTH)
+              }
             }
             END { exit (seen && !bad ? 0 : 1) }
           ' /tmp/sitemap.xml; then

--- a/.github/workflows/reconcile-docs.yml
+++ b/.github/workflows/reconcile-docs.yml
@@ -37,11 +37,11 @@ concurrency:
 
 jobs:
   reconcile:
+    name: Validate deployed docs
     runs-on: ubuntu-latest
-    # v4 §7.3：ALGOLIA_WRITE_KEY 只存在于 GitHub production environment，
-    # 永不进入 EdgeOne 构建环境或静态 bundle
-    environment: production
     timeout-minutes: 30
+    outputs:
+      deployed_sha: ${{ steps.sha.outputs.sha }}
     env:
       VERIFY_ORIGIN: ${{ inputs.verify_origin }}
       EXPECTED_SHA_INPUT: ${{ inputs.expected_sha }}
@@ -50,17 +50,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Set up pnpm 11.22.0
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.22.0
-
-      - name: Set up Node.js 24
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24.18.0'
-          cache: pnpm
 
       - name: Resolve expected SHA
         id: sha
@@ -123,27 +112,39 @@ jobs:
 
           curl -fsSL --max-time 30 "${origin%/}/robots.txt" -o /tmp/robots.txt
           curl -fsSL --max-time 30 "${origin%/}/sitemap.xml" -o /tmp/sitemap.xml
-          if grep -qiE '^Disallow:[[:space:]]*/' /tmp/robots.txt || ! grep -qiE '^Allow:[[:space:]]*/' /tmp/robots.txt; then
-            echo "::error::production robots.txt is not indexable" >&2
-            exit 1
+          if [ "$origin" = "https://docs.tiangong.earth" ]; then
+            if grep -qiE '^Disallow:[[:space:]]*/' /tmp/robots.txt || ! grep -qiE '^Allow:[[:space:]]*/' /tmp/robots.txt; then
+              echo "::error::production robots.txt is not indexable" >&2
+              exit 1
+            fi
+            if ! grep -Fq 'Sitemap: https://docs.tiangong.earth/sitemap.xml' /tmp/robots.txt; then
+              echo "::error::robots.txt does not expose the production sitemap" >&2
+              exit 1
+            fi
+          else
+            if ! grep -qiE '^Disallow:[[:space:]]*/' /tmp/robots.txt || grep -qiE '^Allow:[[:space:]]*/' /tmp/robots.txt; then
+              echo "::error::preview robots.txt must remain non-indexable" >&2
+              exit 1
+            fi
           fi
-          if ! grep -Fq 'Sitemap: https://docs.tiangong.earth/sitemap.xml' /tmp/robots.txt; then
-            echo "::error::robots.txt does not expose the production sitemap" >&2
-            exit 1
-          fi
-          if ! grep -Fq '<loc>https://docs.tiangong.earth/' /tmp/sitemap.xml || grep -FqiE 'localhost|127\.0\.0\.1' /tmp/sitemap.xml; then
-            echo "::error::sitemap.xml does not use the production canonical origin" >&2
+          if ! grep -Fq "<loc>${origin%/}/" /tmp/sitemap.xml || grep -FqiE 'localhost|127\.0\.0\.1' /tmp/sitemap.xml; then
+            echo "::error::sitemap.xml does not use the verified origin" >&2
             exit 1
           fi
           for locale in zh en de fr; do
             page_file="/tmp/${locale}-docs.html"
             curl -fsSL --max-time 30 "${origin%/}/${locale}/docs/" -o "$page_file"
-            if grep -qiE '<meta[^>]+name="robots"[^>]+noindex' "$page_file"; then
-              echo "::error::/${locale}/docs/ is noindex" >&2
+            if [ "$origin" = "https://docs.tiangong.earth" ]; then
+              if grep -qiE '<meta[^>]+name="robots"[^>]+noindex' "$page_file"; then
+                echo "::error::production /${locale}/docs/ is noindex" >&2
+                exit 1
+              fi
+            elif ! grep -qiE '<meta[^>]+name="robots"[^>]+noindex' "$page_file"; then
+              echo "::error::preview /${locale}/docs/ must be noindex" >&2
               exit 1
             fi
-            if ! grep -Fq "<link rel=\"canonical\" href=\"https://docs.tiangong.earth/${locale}/docs/\"" "$page_file"; then
-              echo "::error::/${locale}/docs/ has a non-production canonical" >&2
+            if ! grep -Fq "<link rel=\"canonical\" href=\"${origin%/}/${locale}/docs/\"" "$page_file"; then
+              echo "::error::/${locale}/docs/ has a canonical outside the verified origin" >&2
               exit 1
             fi
           done
@@ -155,26 +156,62 @@ jobs:
               exit 1
             fi
           done
-          echo "live contract validated for $sha"
+          echo "live contract validated for $sha at $origin"
 
-      # --- phase: syncing-search ---
+      - name: Write deployment validation summary
+        if: always()
+        run: |
+          {
+            echo "## Docs deployment validation"
+            echo
+            echo "- Origin: ${VERIFY_ORIGIN}"
+            echo "- SHA: ${{ steps.sha.outputs.sha }}"
+            echo "- Policy: $([ "$VERIFY_ORIGIN" = "https://docs.tiangong.earth" ] && echo production-indexable || echo preview-noindex)"
+            echo "- Outcome: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  reconcile-production-state:
+    name: Sync production publication state
+    needs: reconcile
+    if: inputs.verify_origin == 'https://docs.tiangong.earth'
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+    env:
+      VERIFY_ORIGIN: ${{ inputs.verify_origin }}
+      EXPECTED_SHA: ${{ needs.reconcile.outputs.deployed_sha }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm 11.22.0
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.22.0
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'
+          cache: pnpm
+
       - name: 'Phase: syncing-search (Algolia replaceAllObjects + locale smoke)'
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_WRITE_KEY: ${{ secrets.ALGOLIA_WRITE_KEY }}
           ALGOLIA_INDEX_NAME: tiangong-lca-docs
-          EXPECTED_SHA: ${{ steps.sha.outputs.sha }}
         run: |
           set -euo pipefail
           if [ -z "${ALGOLIA_APP_ID:-}" ] || [ -z "${ALGOLIA_WRITE_KEY:-}" ]; then
-            echo "::error::Algolia production secrets missing; refusing to mark complete (v4 §7.3)"
+            echo "::error::Algolia production secrets missing; refusing to mark complete"
             exit 1
           fi
           # search-sync.mjs uses production dependencies only.
           pnpm install --frozen-lockfile --prod
           node scripts/search-sync.mjs --from "$VERIFY_ORIGIN"
 
-      # --- phase: refreshing-context7 ---
       - name: 'Phase: refreshing-context7'
         id: context7
         env:
@@ -198,7 +235,7 @@ jobs:
             cat /tmp/context7-response.json || true
             exit 0
           fi
-          # too-early：Context7 强制最小 10 天刷新间隔，项目已在新鲜期内——软跳过
+          # Context7 enforces a 10-day minimum refresh interval; an already-fresh project is a safe skip.
           if grep -q '"too-early"' /tmp/context7-response.json 2>/dev/null; then
             echo "status=too-early" >> "$GITHUB_OUTPUT"
             echo "::warning::Context7 refresh skipped: within the 10-day minimum interval (project already fresh)"
@@ -208,7 +245,6 @@ jobs:
           cat /tmp/context7-response.json || true
           exit 1
 
-      # --- phase: complete ---
       - name: 'Phase: complete (summary)'
         if: always()
         run: |
@@ -216,7 +252,7 @@ jobs:
             echo "## Docs reconcile"
             echo
             echo "- Origin: ${VERIFY_ORIGIN}"
-            echo "- SHA: ${{ steps.sha.outputs.sha }}"
+            echo "- SHA: ${EXPECTED_SHA}"
             echo "- Context7: ${{ steps.context7.outputs.status || 'not-run' }}"
             echo "- Outcome: ${{ job.status }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reconcile-docs.yml
+++ b/.github/workflows/reconcile-docs.yml
@@ -132,7 +132,13 @@ jobs:
             echo "::error::sitemap.xml does not use the production canonical origin" >&2
             exit 1
           fi
-          if grep -E '<loc>|<xhtml:link' /tmp/sitemap.xml | grep -Fvq "https://docs.tiangong.earth/"; then
+          if ! awk -v origin="${canonical_origin}/" '
+            /<loc>|<xhtml:link/ {
+              seen = 1
+              if (index($0, origin) == 0) bad = 1
+            }
+            END { exit (seen && !bad ? 0 : 1) }
+          ' /tmp/sitemap.xml; then
             echo "::error::sitemap.xml mixes canonical origins or contains relative URLs" >&2
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ This repository does not own shipped product behavior, route truth, API semantic
 - The shared `SiteBrand` and `DocsHome` components plus `app/global.css` define the Data Atlas visual contract. Keep both documentation sites aligned with its shell widths, brand lockup, color tokens, focus treatment, dark mode, and responsive behavior.
 - `next.config.ts` sets `agentRules: false` because this governed file, not generated development-server text, is authoritative.
 - Public AI retrieval is derived at build time through `/llms.txt` and `/search-records.json`; internal governance files remain excluded by `context7.json`.
-- Reconciliation has two trust boundaries: production validates indexability and then enters the GitHub production environment for Algolia/Context7 mutation; preview validates `noindex`/robots/canonical policy in a separate job path that cannot access those mutation steps.
+- Reconciliation has two trust boundaries: production validates indexability and then enters the GitHub production environment for Algolia/Context7 mutation; preview validates `noindex`/robots plus production-canonical policy in a separate job path that cannot access those mutation steps.
 
 ## Required commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ This repository does not own shipped product behavior, route truth, API semantic
 - The shared `SiteBrand` and `DocsHome` components plus `app/global.css` define the Data Atlas visual contract. Keep both documentation sites aligned with its shell widths, brand lockup, color tokens, focus treatment, dark mode, and responsive behavior.
 - `next.config.ts` sets `agentRules: false` because this governed file, not generated development-server text, is authoritative.
 - Public AI retrieval is derived at build time through `/llms.txt` and `/search-records.json`; internal governance files remain excluded by `context7.json`.
+- Reconciliation has two trust boundaries: production validates indexability and then enters the GitHub production environment for Algolia/Context7 mutation; preview validates `noindex`/robots/canonical policy in a separate job path that cannot access those mutation steps.
 
 ## Required commands
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ EdgeOne Makers owns build and deployment. GitHub Actions validates pull requests
 
 Writing credentials stay in the GitHub production environment and never enter the static bundle. The browser receives only the restricted search configuration required by production search.
 
+The manual preview reconciliation choice is validation-only: it requires preview `Disallow: /`, page `noindex`, and preview-origin canonical/sitemap URLs. Its production-state job is skipped, so preview records cannot replace production Algolia data or request a Context7 refresh.
+
 ## Repository layout
 
 ```text

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ EdgeOne Makers owns build and deployment. GitHub Actions validates pull requests
 
 Writing credentials stay in the GitHub production environment and never enter the static bundle. The browser receives only the restricted search configuration required by production search.
 
-The manual preview reconciliation choice is validation-only: it requires preview `Disallow: /`, page `noindex`, and preview-origin canonical/sitemap URLs. Its production-state job is skipped, so preview records cannot replace production Algolia data or request a Context7 refresh.
+The manual preview reconciliation choice is validation-only: it requires preview `Disallow: /`, page `noindex`, and production-origin canonical/sitemap URLs so preview never becomes a competing canonical site. Its production-state job is skipped, so preview records cannot replace production Algolia data or request a Context7 refresh.
 
 ## Repository layout
 

--- a/TODO.docs-system-gaps.md
+++ b/TODO.docs-system-gaps.md
@@ -53,4 +53,4 @@ No active repository-local drift is known after Issue #136.
 - Root `/` renders the full default-language home without redirect compatibility.
 - Generated routes, public endpoints, search records, AI index, metadata, local links, fragments, and assets are build-gated.
 - Visual changes require real-browser inspection at mobile, desktop, ultra-wide, light, and dark states.
-- EdgeOne reconciliation validates source identity and indexing policy for both allowlisted origins; only production may mutate Algolia or Context7 state, while preview remains validation-only.
+- EdgeOne reconciliation validates source identity and indexing policy for both allowlisted origins; preview canonicalizes to production, and only production may mutate Algolia or Context7 state.

--- a/TODO.docs-system-gaps.md
+++ b/TODO.docs-system-gaps.md
@@ -53,4 +53,4 @@ No active repository-local drift is known after Issue #136.
 - Root `/` renders the full default-language home without redirect compatibility.
 - Generated routes, public endpoints, search records, AI index, metadata, local links, fragments, and assets are build-gated.
 - Visual changes require real-browser inspection at mobile, desktop, ultra-wide, light, and dark states.
-- EdgeOne deployment reconciliation keeps the live source commit, Algolia, and Context7 state observable.
+- EdgeOne reconciliation validates source identity and indexing policy for both allowlisted origins; only production may mutate Algolia or Context7 state, while preview remains validation-only.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -91,7 +91,7 @@ All four variants must change together when structure, links, examples, or user-
 
 The three retained `manifests/p0b/*.json` files are immutable build contracts for information architecture, expected routes, and retired-path denial. One-time rewrite inventories and executors were removed after cutover; Git history remains the audit source.
 
-EdgeOne Makers builds and deploys from Git. GitHub workflows validate pull requests and first reconcile any allowlisted deployment against its source SHA and environment-specific indexing policy. Only the production origin can start the separate production-environment job that replaces Algolia data and refreshes Context7; preview reconciliation is validation-only.
+EdgeOne Makers builds and deploys from Git. GitHub workflows validate pull requests and first reconcile any allowlisted deployment against its source SHA and environment-specific indexing policy. Preview stays `noindex` and canonicalizes to production. Only the production origin can start the separate production-environment job that replaces Algolia data and refreshes Context7; preview reconciliation is validation-only.
 
 ## Ownership boundaries
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -91,7 +91,7 @@ All four variants must change together when structure, links, examples, or user-
 
 The three retained `manifests/p0b/*.json` files are immutable build contracts for information architecture, expected routes, and retired-path denial. One-time rewrite inventories and executors were removed after cutover; Git history remains the audit source.
 
-EdgeOne Makers builds and deploys from Git. GitHub workflows validate pull requests and reconcile the deployed source commit with search and Context7 state.
+EdgeOne Makers builds and deploys from Git. GitHub workflows validate pull requests and first reconcile any allowlisted deployment against its source SHA and environment-specific indexing policy. Only the production origin can start the separate production-environment job that replaces Algolia data and refreshes Context7; preview reconciliation is validation-only.
 
 ## Ownership boundaries
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -58,7 +58,7 @@ DEPLOY_ENV=ci CANONICAL_ORIGIN=http://localhost:3000 NEXT_PUBLIC_SEARCH_MODE=sta
 - Layout, CSS, brand, search dialog, or responsive behavior: run typecheck and build, then inspect a real browser at 390px, 1440px, and an ultra-wide viewport in light and dark themes. Confirm keyboard focus, language switching, search, mobile menu, and zero horizontal overflow.
 - Metadata or route changes: inspect generated HTML for canonical, `x-default`, all real locale alternatives, and Open Graph image metadata; confirm sitemap entries and negative 404 contracts.
 - Production publishing or search reconciliation: run the complete build, verify deployed `/llms.txt` and `/search-records.json` expose the expected SHA, assert indexable robots/canonical metadata, then confirm locale-isolated Algolia search.
-- Preview reconciliation: assert the same deployed SHA but require `Disallow: /`, page `noindex`, and preview-origin canonical/sitemap URLs; confirm the production-state job is skipped.
+- Preview reconciliation: assert the same deployed SHA but require `Disallow: /`, page `noindex`, and production-origin canonical/sitemap URLs; confirm the production-state job is skipped.
 - Governance: validate and lint Docpact after the implementation diff is final.
 
 ## Docpact

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -57,7 +57,8 @@ DEPLOY_ENV=ci CANONICAL_ORIGIN=http://localhost:3000 NEXT_PUBLIC_SEARCH_MODE=sta
 - Links, anchors, navigation, or assets: run link unit tests and the complete build. `check:links` must report zero missing pages, fragments, or local assets.
 - Layout, CSS, brand, search dialog, or responsive behavior: run typecheck and build, then inspect a real browser at 390px, 1440px, and an ultra-wide viewport in light and dark themes. Confirm keyboard focus, language switching, search, mobile menu, and zero horizontal overflow.
 - Metadata or route changes: inspect generated HTML for canonical, `x-default`, all real locale alternatives, and Open Graph image metadata; confirm sitemap entries and negative 404 contracts.
-- Publishing or search reconciliation: run the complete build, verify deployed `/llms.txt` and `/search-records.json` expose the expected SHA, then confirm locale-isolated search.
+- Production publishing or search reconciliation: run the complete build, verify deployed `/llms.txt` and `/search-records.json` expose the expected SHA, assert indexable robots/canonical metadata, then confirm locale-isolated Algolia search.
+- Preview reconciliation: assert the same deployed SHA but require `Disallow: /`, page `noindex`, and preview-origin canonical/sitemap URLs; confirm the production-state job is skipped.
 - Governance: validate and lint Docpact after the implementation diff is final.
 
 ## Docpact


### PR DESCRIPTION
Closes #138

Follow-up to #137  
Parent coordination: tiangong-lca/workspace#659

## Outcome

- Separate allowlisted deployment validation from production publication-state mutation.
- Validate production as indexable with exact root robots rules and production canonical/sitemap URLs.
- Validate preview as root `Disallow: /` + no `Allow:` exceptions + page `noindex`, while canonicalizing every page/sitemap alternate to production.
- Reject mixed, relative, localhost, or preview-host sitemap canonical URLs.
- Guard the Algolia/Context7 job by the exact production origin and keep its referenced secrets inside the GitHub production environment.
- Remove stale repository-level Cloudflare secrets from next-docs and TIDAS plus the duplicate next-docs repository-level Context7 secret.
- Restrict the next-docs `production` environment to the custom deployment branch policy `main`.
- Document the two trust boundaries in AGENTS, README, architecture, validation, and the durable drift baseline.

## Validation

- workflow YAML parse and source trust-boundary assertions: pass
- adversarial robots fixtures distinguish `/` from `/private`: pass
- mixed-origin sitemap fixture is rejected: pass
- production-mode build and indexable/production-canonical fixture: pass
- preview-mode build with noindex/Disallow/production-canonical fixture: pass
- both builds: 396 pages; 12,443 internal references; all output checks green
- Markdown lint/typecheck: pass
- Docpact strict/enforce: 0 problems/findings/uncovered/stale docs
- `git diff --check`: clean
- GitHub environment readback: custom branch policies enabled, exactly one branch policy (`main`), production secrets preserved

## Risk

- The preview domain is validation-only by design; it will not update Algolia or Context7.
- Automatic main reconciliation passes the production origin and therefore executes both the validation and production-state jobs.
- Deleted GitHub secrets are not recoverable except by reconfiguration; no current workflow references the removed Cloudflare keys, and the required Context7 environment copy remains.
