### PR TITLE
feat(docs): adopt purple LCA concept landing

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,9 +1,9 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-23"
-lastReviewedCommit: "41cad9bf624f7ae87d4961140be33747710000df"
-reviewNote: "Reviewed for Issue #138: preview deployment validation is isolated from production Algolia and Context7 mutation; routing and rule topology remain correct."
-lastReviewedNote: "Production reconciliation retains the publication mutation boundary; preview stays noindex, canonicalizes to production, and remains validation-only."
+lastReviewedCommit: "19a92c256d967cbed023e8f75f1af0ac6ff39940"
+reviewNote: "Reviewed for Issue #140: the landing redesign remains inside existing docs-site ownership and coverage; routing and rule topology remain correct."
+lastReviewedNote: "The Fumadocs primitive, theme-token, and LCA concept-map changes require no ownership, routing, coverage, or publication-rule changes."
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - .github/workflows/**
   - .githooks/**
 lastReviewedAt: "2026-08-23"
-lastReviewedCommit: d4f91b9c1d5a1e37f212da006a7ee75a1555c456
-lastReviewedNote: "Reviewed for Issue #136 after the Data Atlas UI, four-locale link repair, metadata, and permanent generated-output link gate were implemented."
+lastReviewedCommit: 88952727c75ac491473cb9dc295651a1fc0b165d
+lastReviewedNote: "Reviewed for Issue #140 after the landing adopted the flat shared documentation shell, a TianGong LCA concept map, task-specific four-locale copy, and Fumadocs UI primitives."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md
@@ -65,7 +65,7 @@ related:
 This repository owns:
 
 - `content/docs/**` as public content using dot-locale files: Chinese `page.mdx`, then `page.en.mdx`, `page.de.mdx`, and `page.fr.mdx`;
-- `app/**`, `components/**`, `lib/**`, and `app/global.css` for routing, metadata, the shared Data Atlas presentation, search, and MDX rendering;
+- `app/**`, `components/**`, `lib/**`, and `app/global.css` for routing, metadata, the shared documentation presentation, search, and MDX rendering;
 - `public/**` for public media and brand assets;
 - `scripts/build.mjs`, `scripts/verify-out.mjs`, and `scripts/check-links.mjs` for the static output contract;
 - `TODO.docs-system-gaps.md` for durable product/documentation drift.
@@ -77,7 +77,9 @@ This repository does not own shipped product behavior, route truth, API semantic
 - Supported locales are `zh`, `en`, `de`, and `fr`; every public page currently exists in all four.
 - `/` renders the complete Chinese home as the `x-default` entry without redirecting. Locale homes remain `/{lang}/`; documents remain `/{lang}/docs/**`.
 - Retired paths have no redirect or rewrite compatibility and must remain 404. `manifests/p0b/greenfield-deny.json` is a negative build contract, not a mapping table.
-- The shared `SiteBrand` and `DocsHome` components plus `app/global.css` define the Data Atlas visual contract. Keep both documentation sites aligned with its shell widths, brand lockup, color tokens, focus treatment, dark mode, and responsive behavior.
+- `SiteBrand`, `DocsHome`, and the Fumadocs Neutral theme define the shared documentation shell. Keep both documentation sites aligned on the 72rem shell, brand-lockup structure, solid plum interaction color, neutral layers, focus treatment, dark mode, low-radius controls, and responsive behavior.
+- Product identity belongs in a semantic hero signature rather than a shared decorative motif. This site uses `data-hero-signature="lca-concept-map"` for the reference-data → process-relations → product-system → LCIA-results concept map; TIDAS must retain a distinct data-system/schema signature.
+- Reuse exported Fumadocs primitives such as `buttonVariants`, `Card`, and `Cards`. Custom presentation is limited to theme tokens, the shared shell, and the product-specific concept figure; do not add gradients, glow, shadow, or lift animation to landing actions.
 - `next.config.ts` sets `agentRules: false` because this governed file, not generated development-server text, is authoritative.
 - Public AI retrieval is derived at build time through `/llms.txt` and `/search-records.json`; internal governance files remain excluded by `context7.json`.
 - Reconciliation has two trust boundaries: production validates indexability and then enters the GitHub production environment for Algolia/Context7 mutation; preview validates `noindex`/robots plus production-canonical policy in a separate job path that cannot access those mutation steps.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ checkPaths:
   - crowdin.yml
   - .github/workflows/**
 lastReviewedAt: 2026-08-23
-lastReviewedCommit: d4f91b9c1d5a1e37f212da006a7ee75a1555c456
-lastReviewedNote: "Reviewed for Issue #136 after Data Atlas UI, four-locale publication, generated link validation, and governance cleanup."
+lastReviewedCommit: 88952727c75ac491473cb9dc295651a1fc0b165d
+lastReviewedNote: "Reviewed for Issue #140 after the four-locale landing adopted the shared flat documentation shell and a Next-specific LCA concept map."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -98,8 +98,8 @@ The manual preview reconciliation choice is validation-only: it requires preview
 ## Repository layout
 
 ```text
-app/             routes, metadata, public endpoints, global Data Atlas styles
-components/      shared brand/home, search, MDX, and media components
+app/             routes, metadata, public endpoints, and shared neutral theme tokens
+components/      shared brand/home, LCA concept map, search, MDX, and media components
 content/docs/    four-locale dot-suffix MDX sources
 lib/             locale, source, metadata, information architecture, layout options
 public/          brand and documentation media

--- a/TODO.docs-system-gaps.md
+++ b/TODO.docs-system-gaps.md
@@ -18,8 +18,8 @@ checkPaths:
   - components/**
   - lib/**
 lastReviewedAt: 2026-08-23
-lastReviewedCommit: d4f91b9c1d5a1e37f212da006a7ee75a1555c456
-lastReviewedNote: "Issue #136 reconciled the completed site rewrite, four-locale publication, links, presentation, validation, and deployment documentation; no active repository-local drift remains."
+lastReviewedCommit: 88952727c75ac491473cb9dc295651a1fc0b165d
+lastReviewedNote: "Reviewed for Issue #140 after the landing copy and LCA concept map were reconciled across all four locales; no product/documentation drift was introduced."
 related:
   - AGENTS.md
   - README.md

--- a/app/global.css
+++ b/app/global.css
@@ -7,85 +7,78 @@ html {
 }
 
 :root {
-  --atlas-plum: #5c246a;
-  --atlas-violet: #9e3ffd;
-  --atlas-amber: #efb134;
-  --atlas-plum-ink: #5c246a;
-  --atlas-violet-ink: #7520c8;
-  --atlas-amber-ink: #6d4900;
-  --atlas-ink: #211625;
-  --atlas-paper: #f8f6f9;
-  --atlas-line: color-mix(in srgb, var(--atlas-plum) 18%, transparent);
-  --atlas-panel: color-mix(in srgb, white 86%, var(--atlas-violet) 14%);
-  --color-fd-primary: var(--atlas-plum);
+  --color-fd-background: #fff;
+  --color-fd-foreground: #161616;
+  --color-fd-muted: #f4f4f4;
+  --color-fd-muted-foreground: #525252;
+  --color-fd-popover: #fff;
+  --color-fd-popover-foreground: #161616;
+  --color-fd-card: #f4f4f4;
+  --color-fd-card-foreground: #161616;
+  --color-fd-border: #e0e0e0;
+  --color-fd-primary: #5c246a;
   --color-fd-primary-foreground: #fff;
-  --color-fd-ring: var(--atlas-violet);
-  --color-fd-accent: color-mix(in srgb, var(--atlas-violet) 11%, transparent);
-  --color-fd-accent-foreground: var(--atlas-ink);
+  --color-fd-secondary: #f4f4f4;
+  --color-fd-secondary-foreground: #161616;
+  --color-fd-accent: #eee8f0;
+  --color-fd-accent-foreground: #161616;
+  --color-fd-ring: #5c246a;
 }
 
 .dark {
-  --atlas-plum: #c99cff;
-  --atlas-violet: #a855f7;
-  --atlas-amber: #f4bd52;
-  --atlas-plum-ink: var(--atlas-plum);
-  --atlas-violet-ink: var(--atlas-violet);
-  --atlas-amber-ink: var(--atlas-amber);
-  --atlas-ink: #f5edf8;
-  --atlas-paper: #120d15;
-  --atlas-line: color-mix(in srgb, var(--atlas-violet) 28%, transparent);
-  --atlas-panel: color-mix(in srgb, #18101c 88%, var(--atlas-violet) 12%);
-  --color-fd-primary: var(--atlas-plum);
-  --color-fd-primary-foreground: #1c1021;
-  --color-fd-ring: var(--atlas-violet);
-  --color-fd-accent: color-mix(in srgb, var(--atlas-violet) 18%, transparent);
-  --color-fd-accent-foreground: #fff;
+  --color-fd-background: #161616;
+  --color-fd-foreground: #f4f4f4;
+  --color-fd-muted: #262626;
+  --color-fd-muted-foreground: #c6c6c6;
+  --color-fd-popover: #262626;
+  --color-fd-popover-foreground: #f4f4f4;
+  --color-fd-card: #262626;
+  --color-fd-card-foreground: #f4f4f4;
+  --color-fd-border: #393939;
+  --color-fd-primary: #c99cff;
+  --color-fd-primary-foreground: #161616;
+  --color-fd-secondary: #262626;
+  --color-fd-secondary-foreground: #f4f4f4;
+  --color-fd-accent: #35293a;
+  --color-fd-accent-foreground: #f4f4f4;
+  --color-fd-ring: #c99cff;
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--atlas-violet) 28%, transparent);
+  background: color-mix(in srgb, var(--color-fd-primary) 28%, transparent);
 }
 
 :where(a, button, input, select, textarea):focus-visible {
-  outline: 3px solid color-mix(in srgb, var(--atlas-violet) 72%, white);
-  outline-offset: 3px;
+  outline: 2px solid var(--color-fd-ring);
+  outline-offset: 2px;
 }
 
 .atlas-brand {
   display: inline-flex;
   min-width: 0;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.625rem;
   color: var(--color-fd-foreground);
 }
 
 .atlas-brand-mark {
   display: inline-flex;
   flex: none;
-  filter: drop-shadow(0 7px 14px color-mix(in srgb, var(--atlas-plum) 24%, transparent));
 }
 
 .atlas-brand-name {
   overflow: hidden;
-  font-size: 0.925rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.atlas-brand-divider,
 .atlas-brand-product {
-  margin-inline-start: 0.22rem;
-  color: var(--atlas-plum);
-  font-weight: 650;
-}
-
-.atlas-home {
-  min-width: 0;
-  max-width: 100%;
-  flex: 1;
-  overflow: clip;
-  color: var(--color-fd-foreground);
+  color: var(--color-fd-muted-foreground);
+  font-weight: 400;
 }
 
 .atlas-shell {
@@ -96,352 +89,14 @@ html {
   padding-inline: clamp(1rem, 3vw, 2rem);
 }
 
-.atlas-hero {
-  position: relative;
-  border-bottom: 1px solid var(--atlas-line);
-  background:
-    radial-gradient(circle at 76% 20%, color-mix(in srgb, var(--atlas-violet) 15%, transparent), transparent 34rem),
-    linear-gradient(145deg, color-mix(in srgb, var(--atlas-paper) 94%, transparent), var(--color-fd-background));
-}
-
-.atlas-hero::before {
-  position: absolute;
-  inset: 0;
-  background-image: linear-gradient(var(--atlas-line) 1px, transparent 1px), linear-gradient(90deg, var(--atlas-line) 1px, transparent 1px);
-  background-size: 52px 52px;
-  content: '';
-  mask-image: linear-gradient(to bottom, rgb(0 0 0 / 45%), transparent 90%);
-  pointer-events: none;
-}
-
-.atlas-hero-grid {
-  position: relative;
-  display: grid;
-  min-height: min(46rem, calc(100svh - 4rem));
-  grid-template-columns: minmax(0, 1.08fr) minmax(21rem, 0.92fr);
-  align-items: center;
-  gap: clamp(2rem, 6vw, 5rem);
-  padding-block: clamp(4.75rem, 9vw, 8rem);
-}
-
-.atlas-hero-copy {
-  position: relative;
-  min-width: 0;
-  z-index: 1;
-  max-width: 42rem;
-}
-
-.atlas-eyebrow {
+.docs-eyebrow {
   margin: 0 0 1rem;
-  color: var(--atlas-plum);
+  color: var(--color-fd-primary);
   font-size: 0.75rem;
-  font-weight: 760;
-  letter-spacing: 0.1em;
-  line-height: 1.5;
-  text-transform: uppercase;
-}
-
-.atlas-hero h1 {
-  max-width: 13ch;
-  margin: 0;
-  font-size: clamp(2.75rem, 6vw, 5.6rem);
-  font-weight: 760;
-  letter-spacing: -0.062em;
-  line-height: 0.98;
-  overflow-wrap: anywhere;
-  text-wrap: balance;
-}
-
-.atlas-lede {
-  max-width: 42rem;
-  margin: 1.75rem 0 0;
-  color: var(--color-fd-muted-foreground);
-  font-size: clamp(1.05rem, 1.45vw, 1.22rem);
-  line-height: 1.8;
-}
-
-.atlas-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 2.25rem;
-}
-
-.atlas-button {
-  display: inline-flex;
-  min-height: 2.85rem;
-  align-items: center;
-  justify-content: center;
-  gap: 0.55rem;
-  border: 1px solid transparent;
-  border-radius: 0.78rem;
-  padding: 0.72rem 1.05rem;
-  font-size: 0.92rem;
-  font-weight: 680;
-  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
-}
-
-.atlas-button:hover {
-  transform: translateY(-2px);
-}
-
-.atlas-button-primary {
-  background: linear-gradient(120deg, var(--atlas-plum), var(--atlas-violet));
-  box-shadow: 0 14px 35px color-mix(in srgb, var(--atlas-plum) 25%, transparent);
-  color: var(--color-fd-primary-foreground);
-}
-
-.atlas-button-secondary {
-  border-color: var(--atlas-line);
-  background: color-mix(in srgb, var(--color-fd-background) 80%, transparent);
-  color: var(--color-fd-foreground);
-  backdrop-filter: blur(12px);
-}
-
-.atlas-button-secondary:hover {
-  border-color: color-mix(in srgb, var(--atlas-violet) 48%, transparent);
-  background: var(--color-fd-accent);
-}
-
-.atlas-map {
-  position: relative;
-  width: min(100%, 30rem);
-  min-width: 0;
-  max-width: 100%;
-  aspect-ratio: 1;
-  justify-self: end;
-  border: 1px solid var(--atlas-line);
-  border-radius: 2rem;
-  background: color-mix(in srgb, var(--atlas-panel) 78%, transparent);
-  box-shadow: 0 34px 90px color-mix(in srgb, var(--atlas-plum) 15%, transparent);
-  isolation: isolate;
-  overflow: hidden;
-}
-
-.atlas-map-grid {
-  position: absolute;
-  inset: 0;
-  background-image: radial-gradient(circle, var(--atlas-line) 1px, transparent 1.5px);
-  background-size: 22px 22px;
-  opacity: 0.68;
-}
-
-.atlas-map::after {
-  position: absolute;
-  width: 42%;
-  aspect-ratio: 1;
-  border-radius: 999px;
-  background: var(--atlas-amber);
-  content: '';
-  filter: blur(70px);
-  inset: 40% auto auto 54%;
-  opacity: 0.12;
-  z-index: -1;
-}
-
-.atlas-orbit {
-  position: absolute;
-  inset: 15%;
-  border: 1px solid color-mix(in srgb, var(--atlas-violet) 48%, transparent);
-  border-radius: 50%;
-}
-
-.atlas-orbit-two {
-  inset: 27%;
-  border-color: color-mix(in srgb, var(--atlas-amber) 55%, transparent);
-}
-
-.atlas-map-core {
-  position: absolute;
-  inset: 37%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid color-mix(in srgb, var(--atlas-violet) 55%, transparent);
-  border-radius: 50%;
-  background: var(--color-fd-background);
-  box-shadow: 0 15px 45px color-mix(in srgb, var(--atlas-violet) 20%, transparent);
-  flex-direction: column;
-  line-height: 1;
-}
-
-.atlas-map-core span {
-  color: var(--color-fd-muted-foreground);
-  font-size: clamp(0.55rem, 1vw, 0.7rem);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.atlas-map-core strong {
-  margin-top: 0.3rem;
-  color: var(--atlas-plum);
-  font-size: clamp(0.9rem, 2vw, 1.25rem);
-  letter-spacing: -0.04em;
-}
-
-.atlas-map-node {
-  position: absolute;
-  display: flex;
-  min-width: 5.7rem;
-  align-items: center;
-  gap: 0.45rem;
-  border: 1px solid var(--atlas-line);
-  border-radius: 999px;
-  padding: 0.46rem 0.72rem;
-  background: color-mix(in srgb, var(--color-fd-background) 88%, transparent);
-  box-shadow: 0 9px 24px color-mix(in srgb, var(--atlas-plum) 12%, transparent);
-  font-size: clamp(0.68rem, 1.2vw, 0.82rem);
-  font-weight: 650;
-  backdrop-filter: blur(12px);
-}
-
-.atlas-map-node span {
-  color: var(--atlas-violet);
-  font-size: 0.58rem;
-  font-variant-numeric: tabular-nums;
+  font-weight: 600;
   letter-spacing: 0.08em;
-}
-
-.atlas-map-node-1 { inset: 8% auto auto 34%; }
-.atlas-map-node-2 { inset: 40% 4% auto auto; }
-.atlas-map-node-3 { inset: auto 31% 7% auto; }
-.atlas-map-node-4 { inset: 44% auto auto 3%; }
-
-.atlas-paths {
-  padding-block: clamp(4.5rem, 9vw, 7.5rem);
-  background: var(--color-fd-background);
-}
-
-.atlas-section-heading {
-  display: grid;
-  max-width: 48rem;
-  margin-bottom: 2.5rem;
-  gap: 0.65rem;
-}
-
-.atlas-section-heading .atlas-eyebrow {
-  margin-bottom: 0.2rem;
-}
-
-.atlas-section-heading h2,
-.atlas-closing h2 {
-  margin: 0;
-  font-size: clamp(2rem, 4vw, 3.5rem);
-  font-weight: 735;
-  letter-spacing: -0.045em;
-  line-height: 1.08;
-  text-wrap: balance;
-}
-
-.atlas-section-heading > p:last-child,
-.atlas-closing p {
-  margin: 0;
-  color: var(--color-fd-muted-foreground);
-  font-size: 1rem;
-  line-height: 1.75;
-}
-
-.atlas-path-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.atlas-path-card {
-  position: relative;
-  display: grid;
-  min-height: 14.5rem;
-  min-width: 0;
-  align-content: start;
-  border: 1px solid var(--atlas-line);
-  border-radius: 1.25rem;
-  padding: clamp(1.25rem, 3vw, 1.75rem);
-  background: color-mix(in srgb, var(--atlas-panel) 48%, var(--color-fd-background));
-  color: inherit;
-  gap: 0.7rem;
-  overflow: hidden;
-  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
-}
-
-.atlas-path-card::before {
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 3px;
-  background: var(--card-accent);
-  content: '';
-}
-
-.atlas-path-card:hover {
-  border-color: color-mix(in srgb, var(--card-accent) 55%, transparent);
-  box-shadow: 0 22px 55px color-mix(in srgb, var(--card-accent) 13%, transparent);
-  transform: translateY(-4px);
-}
-
-.atlas-accent-plum { --card-accent: var(--atlas-plum); --card-accent-text: var(--atlas-plum-ink); }
-.atlas-accent-violet { --card-accent: var(--atlas-violet); --card-accent-text: var(--atlas-violet-ink); }
-.atlas-accent-amber { --card-accent: var(--atlas-amber); --card-accent-text: var(--atlas-amber-ink); }
-
-.atlas-card-kicker {
-  color: var(--card-accent-text);
-  font-size: 0.66rem;
-  font-weight: 730;
-  letter-spacing: 0.1em;
+  line-height: 1.4;
   text-transform: uppercase;
-}
-
-.atlas-path-card h3 {
-  max-width: 18ch;
-  margin: 0.25rem 0 0;
-  font-size: clamp(1.25rem, 2.4vw, 1.65rem);
-  font-weight: 710;
-  letter-spacing: -0.035em;
-}
-
-.atlas-path-card p {
-  max-width: 42ch;
-  margin: 0;
-  color: var(--color-fd-muted-foreground);
-  line-height: 1.7;
-}
-
-.atlas-card-arrow {
-  position: absolute;
-  right: 1.25rem;
-  bottom: 1.25rem;
-  display: inline-flex;
-  width: 2rem;
-  height: 2rem;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--card-accent) 12%, transparent);
-  color: var(--card-accent);
-}
-
-.atlas-closing {
-  padding: 0 0 clamp(4.5rem, 9vw, 7rem);
-}
-
-.atlas-closing-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border: 1px solid var(--atlas-line);
-  border-radius: 1.5rem;
-  background:
-    linear-gradient(120deg, color-mix(in srgb, var(--atlas-plum) 9%, var(--color-fd-background)), color-mix(in srgb, var(--atlas-amber) 8%, var(--color-fd-background)));
-  gap: 2rem;
-  padding-block: clamp(1.5rem, 4vw, 2.5rem);
-}
-
-.atlas-closing-card > div {
-  display: grid;
-  max-width: 42rem;
-  gap: 0.55rem;
-}
-
-.atlas-closing h2 {
-  font-size: clamp(1.5rem, 3vw, 2.3rem);
 }
 
 .docs-pagination {
@@ -454,72 +109,18 @@ html {
   overflow: hidden;
 }
 
-@media (max-width: 52rem) {
-  .atlas-hero-grid {
-    min-height: auto;
-    grid-template-columns: minmax(0, 1fr);
-    padding-block: 5rem 4rem;
-  }
-
-  .atlas-map {
-    width: min(100%, 27rem);
-    justify-self: center;
-  }
-}
-
 @media (max-width: 40rem) {
   .atlas-brand-name {
-    max-width: 10.5rem;
-    font-size: 0.86rem;
+    max-width: 12rem;
+    font-size: 0.8125rem;
   }
 
-  .atlas-hero h1 {
-    max-width: 100%;
-    font-size: clamp(2.25rem, 10.5vw, 3.25rem);
-    letter-spacing: -0.055em;
-  }
-
-  .atlas-actions,
-  .atlas-closing-card {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .atlas-button {
-    width: 100%;
-  }
-
-  .atlas-path-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .atlas-path-card {
-    min-height: 13rem;
+  .atlas-brand-divider,
+  .atlas-brand-product {
+    display: none;
   }
 
   .docs-pagination {
     grid-template-columns: minmax(0, 1fr);
   }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .atlas-orbit-one {
-    animation: atlas-spin 28s linear infinite;
-  }
-
-  .atlas-map-node {
-    animation: atlas-float 5s ease-in-out infinite alternate;
-  }
-
-  .atlas-map-node:nth-of-type(even) {
-    animation-delay: -2.5s;
-  }
-}
-
-@keyframes atlas-spin {
-  to { transform: rotate(360deg); }
-}
-
-@keyframes atlas-float {
-  to { transform: translateY(-5px); }
 }

--- a/components/docs-home.tsx
+++ b/components/docs-home.tsx
@@ -1,8 +1,17 @@
 import Link from 'next/link';
+import { Card, Cards } from 'fumadocs-ui/components/card';
+import { buttonVariants } from 'fumadocs-ui/components/ui/button';
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { LcaConceptMap, type ConceptMapCopy } from '@/components/lca-concept-map';
 import { baseOptions } from '@/lib/layout.shared';
 
 type Language = 'zh' | 'en' | 'de' | 'fr';
+
+interface HomePath {
+  title: string;
+  description: string;
+  slug: string;
+}
 
 interface HomeCopy {
   eyebrow: string;
@@ -10,105 +19,141 @@ interface HomeCopy {
   description: string;
   primary: string;
   secondary: string;
-  mapLabel: string;
-  mapNodes: [string, string, string, string];
   pathsEyebrow: string;
   pathsTitle: string;
   pathsDescription: string;
-  paths: Array<{ title: string; description: string; slug: string; accent: string }>;
-  closingTitle: string;
-  closingDescription: string;
-  closingAction: string;
+  openGuide: string;
+  paths: HomePath[];
+  technicalLabel: string;
+  integrationAction: string;
+  deploymentAction: string;
+  conceptMap: ConceptMapCopy;
 }
 
 const copy: Record<Language, HomeCopy> = {
   zh: {
-    eyebrow: 'TianGong Data Atlas · 生命周期评价知识入口',
-    title: '从数据到决策，读懂 TianGong LCA',
+    eyebrow: 'TianGong LCA · 开源生命周期评价平台',
+    title: '查找数据、建立模型，完成生命周期评价',
     description:
-      '围绕真实工作流组织的平台文档：快速上手数据检索与建模，理解 LCIA 分析、数据评审、团队协作与开放集成。',
-    primary: '开始使用',
-    secondary: '浏览用户指南',
-    mapLabel: 'TianGong LCA 数据从采集、建模、评价到共享的循环',
-    mapNodes: ['采集', '建模', '评价', '共享'],
-    pathsEyebrow: '按任务探索',
-    pathsTitle: '从你现在要完成的工作开始',
-    pathsDescription: '不用先理解整套系统。选择一个入口，文档会带你走到可验证的结果。',
+      'TianGong LCA 将标准化数据、过程建模、LCIA 计算和团队评审连接在一个工作区。按任务查阅文档，从检索数据开始，直到解释结果。',
+    primary: '完成首次操作',
+    secondary: '浏览任务指南',
+    pathsEyebrow: '任务指南',
+    pathsTitle: '从要完成的工作开始',
+    pathsDescription: '选择一个任务，直接进入对应步骤、界面说明和结果检查。',
+    openGuide: '打开指南',
     paths: [
-      { title: '认识平台', description: '了解 TianGong LCA 的定位、数据空间与核心能力。', slug: 'overview', accent: 'plum' },
-      { title: '快速开始', description: '完成首次登录、查找数据并建立第一个工作流。', slug: 'quick-start', accent: 'violet' },
-      { title: '完成 LCA 工作', description: '按真实任务学习数据、模型、LCIA、评审与团队协作。', slug: 'user-guide', accent: 'amber' },
-      { title: '连接你的工具', description: '使用 MCP、CLI 与 OpenAPI 接入 TianGong 数据能力。', slug: 'integration', accent: 'plum' },
+      { title: '查找和使用数据', description: '搜索数据空间，查看数据集，并引用或复制所需记录。', slug: 'user-guide/data' },
+      { title: '创建数据与模型', description: '建立流和过程，连接交换，准备可计算的模型。', slug: 'user-guide/create-my-data' },
+      { title: '计算和解读 LCIA', description: '运行影响评价，查看过程或模型的结果。', slug: 'user-guide/lcia' },
+      { title: '评审与团队协作', description: '提交数据、处理反馈，并在团队数据空间协作。', slug: 'user-guide/data-review' },
     ],
-    closingTitle: '需要一个最短路径？',
-    closingDescription: '从快速开始进入，十分钟内熟悉数据空间、搜索与核心操作。',
-    closingAction: '打开快速开始',
+    technicalLabel: '面向开发者与运维',
+    integrationAction: '连接 MCP、CLI 与 OpenAPI',
+    deploymentAction: '查看私有部署与开发',
+    conceptMap: {
+      ariaLabel: '生命周期评价概念图：参考数据连接过程关系，形成产品系统并生成 LCIA 结果。',
+      referenceLabel: '参考数据',
+      referenceItems: ['过程数据', '基本流', '影响方法'],
+      relationsLabel: '过程关系',
+      relationItems: ['材料', '电力', '制造'],
+      productSystemLabel: '产品系统',
+      resultsLabel: 'LCIA 结果',
+      impactLabels: ['气候变化', '资源使用'],
+    },
   },
   en: {
-    eyebrow: 'TianGong Data Atlas · Life cycle knowledge, mapped',
-    title: 'Move from data to decisions with TianGong LCA',
+    eyebrow: 'TianGong LCA · Open life cycle assessment platform',
+    title: 'Find data, build models, and complete an LCA',
     description:
-      'Documentation organised around real work: discover and model data, interpret LCIA, review contributions, collaborate with teams, and connect open tools.',
-    primary: 'Get started',
-    secondary: 'Browse the user guide',
-    mapLabel: 'The TianGong LCA data cycle from collection and modelling to assessment and sharing',
-    mapNodes: ['Collect', 'Model', 'Assess', 'Share'],
-    pathsEyebrow: 'Explore by task',
-    pathsTitle: 'Start with the work in front of you',
-    pathsDescription: 'You do not need to learn the whole platform first. Pick a path and reach a verifiable result.',
+      'TianGong LCA brings standardised data, process modelling, LCIA, and team review into one workspace. Follow the documentation by task, from finding data to interpreting results.',
+    primary: 'Complete the first steps',
+    secondary: 'Browse task guides',
+    pathsEyebrow: 'Task guides',
+    pathsTitle: 'Start with the task you need to complete',
+    pathsDescription: 'Choose a task to open the relevant steps, interface guidance, and result checks.',
+    openGuide: 'Open guide',
     paths: [
-      { title: 'Understand the platform', description: 'Learn the purpose, data spaces, and core capabilities of TianGong LCA.', slug: 'overview', accent: 'plum' },
-      { title: 'Get started', description: 'Sign in, find data, and complete your first platform workflow.', slug: 'quick-start', accent: 'violet' },
-      { title: 'Do LCA work', description: 'Follow real tasks across data, models, LCIA, review, and teamwork.', slug: 'user-guide', accent: 'amber' },
-      { title: 'Connect your tools', description: 'Use MCP, CLI, and OpenAPI to integrate TianGong data capabilities.', slug: 'integration', accent: 'plum' },
+      { title: 'Find and use data', description: 'Search data spaces, inspect datasets, and reference or copy the records you need.', slug: 'user-guide/data' },
+      { title: 'Create data and models', description: 'Build flows and processes, connect exchanges, and prepare a model for assessment.', slug: 'user-guide/create-my-data' },
+      { title: 'Calculate and interpret LCIA', description: 'Run impact assessment and read results for processes and models.', slug: 'user-guide/lcia' },
+      { title: 'Review and collaborate', description: 'Submit contributions for review, address feedback, and work in team data spaces.', slug: 'user-guide/data-review' },
     ],
-    closingTitle: 'Looking for the shortest path?',
-    closingDescription: 'Use Quick Start to learn data spaces, search, and the essential controls in about ten minutes.',
-    closingAction: 'Open Quick Start',
+    technicalLabel: 'For developers and operators',
+    integrationAction: 'Connect MCP, CLI, and OpenAPI',
+    deploymentAction: 'View self-hosting and development',
+    conceptMap: {
+      ariaLabel: 'Life cycle assessment concept map: reference data connects process relationships to a product system and LCIA results.',
+      referenceLabel: 'Reference data',
+      referenceItems: ['Process data', 'Elementary flows', 'Impact methods'],
+      relationsLabel: 'Process relations',
+      relationItems: ['Material', 'Electricity', 'Manufacturing'],
+      productSystemLabel: 'Product system',
+      resultsLabel: 'LCIA results',
+      impactLabels: ['Climate change', 'Resource use'],
+    },
   },
   de: {
-    eyebrow: 'TianGong Data Atlas · Lebenszykluswissen im Überblick',
-    title: 'Mit TianGong LCA von Daten zu Entscheidungen',
+    eyebrow: 'TianGong LCA · Offene Plattform für Ökobilanzen',
+    title: 'Daten finden, Modelle erstellen und eine Ökobilanz durchführen',
     description:
-      'Dokumentation entlang realer Aufgaben: Daten finden und modellieren, LCIA auswerten, Beiträge prüfen, im Team arbeiten und offene Werkzeuge anbinden.',
-    primary: 'Erste Schritte',
-    secondary: 'Benutzerhandbuch öffnen',
-    mapLabel: 'Der TianGong-LCA-Datenkreislauf von Erfassung und Modellierung bis Bewertung und Austausch',
-    mapNodes: ['Erfassen', 'Modellieren', 'Bewerten', 'Teilen'],
-    pathsEyebrow: 'Nach Aufgabe erkunden',
+      'TianGong LCA vereint standardisierte Daten, Prozessmodellierung, Wirkungsabschätzung und Teamprüfung in einem Arbeitsbereich. Folgen Sie der Dokumentation nach Aufgabe – von der Datensuche bis zur Interpretation der Ergebnisse.',
+    primary: 'Erste Schritte durchführen',
+    secondary: 'Aufgabenguides ansehen',
+    pathsEyebrow: 'Aufgabenguides',
     pathsTitle: 'Beginnen Sie mit Ihrer aktuellen Aufgabe',
-    pathsDescription: 'Sie müssen nicht zuerst die gesamte Plattform lernen. Wählen Sie einen Weg zu einem prüfbaren Ergebnis.',
+    pathsDescription: 'Wählen Sie eine Aufgabe, um direkt die passenden Schritte, Bedienhinweise und Ergebniskontrollen zu öffnen.',
+    openGuide: 'Guide öffnen',
     paths: [
-      { title: 'Plattform verstehen', description: 'Zweck, Datenräume und Kernfunktionen von TianGong LCA kennenlernen.', slug: 'overview', accent: 'plum' },
-      { title: 'Schnell starten', description: 'Anmelden, Daten finden und den ersten Arbeitsablauf abschließen.', slug: 'quick-start', accent: 'violet' },
-      { title: 'LCA-Aufgaben erledigen', description: 'Daten, Modelle, LCIA, Prüfung und Teamarbeit praxisnah nutzen.', slug: 'user-guide', accent: 'amber' },
-      { title: 'Werkzeuge anbinden', description: 'TianGong-Funktionen über MCP, CLI und OpenAPI integrieren.', slug: 'integration', accent: 'plum' },
+      { title: 'Daten finden und verwenden', description: 'Datenräume durchsuchen, Datensätze prüfen und benötigte Einträge referenzieren oder kopieren.', slug: 'user-guide/data' },
+      { title: 'Daten und Modelle erstellen', description: 'Flüsse und Prozesse anlegen, Austausche verknüpfen und ein berechenbares Modell vorbereiten.', slug: 'user-guide/create-my-data' },
+      { title: 'LCIA berechnen und auswerten', description: 'Wirkungsabschätzungen durchführen und Ergebnisse für Prozesse oder Modelle auswerten.', slug: 'user-guide/lcia' },
+      { title: 'Prüfen und zusammenarbeiten', description: 'Daten zur Prüfung einreichen, Rückmeldungen bearbeiten und in Team-Datenräumen arbeiten.', slug: 'user-guide/data-review' },
     ],
-    closingTitle: 'Sie suchen den kürzesten Weg?',
-    closingDescription: 'Der Schnellstart erklärt Datenräume, Suche und zentrale Bedienung in etwa zehn Minuten.',
-    closingAction: 'Schnellstart öffnen',
+    technicalLabel: 'Für Entwicklung und Betrieb',
+    integrationAction: 'MCP, CLI und OpenAPI anbinden',
+    deploymentAction: 'Self-Hosting und Entwicklung ansehen',
+    conceptMap: {
+      ariaLabel: 'Konzeptkarte der Ökobilanz: Referenzdaten verbinden Prozessbeziehungen mit dem Produktsystem und den LCIA-Ergebnissen.',
+      referenceLabel: 'Referenzdaten',
+      referenceItems: ['Prozessdaten', 'Elementarflüsse', 'Wirkungsmethoden'],
+      relationsLabel: 'Prozessbeziehungen',
+      relationItems: ['Material', 'Strom', 'Herstellung'],
+      productSystemLabel: 'Produktsystem',
+      resultsLabel: 'LCIA-Ergebnisse',
+      impactLabels: ['Klimawandel', 'Ressourcennutzung'],
+    },
   },
   fr: {
-    eyebrow: 'TianGong Data Atlas · Les connaissances du cycle de vie, cartographiées',
-    title: 'Passez des données aux décisions avec TianGong LCA',
+    eyebrow: 'TianGong LCA · Plateforme ouverte d’analyse du cycle de vie',
+    title: 'Trouvez des données, construisez des modèles et réalisez une ACV',
     description:
-      'Une documentation structurée autour du travail réel : trouver et modéliser des données, interpréter la LCIA, réviser les contributions, collaborer et connecter des outils ouverts.',
-    primary: 'Bien démarrer',
-    secondary: 'Parcourir le guide utilisateur',
-    mapLabel: "Le cycle de données TianGong LCA, de la collecte et la modélisation à l'évaluation et au partage",
-    mapNodes: ['Collecter', 'Modéliser', 'Évaluer', 'Partager'],
-    pathsEyebrow: 'Explorer par tâche',
-    pathsTitle: 'Commencez par le travail à accomplir',
-    pathsDescription: "Nul besoin d'apprendre toute la plateforme. Choisissez un parcours vers un résultat vérifiable.",
+      'TianGong LCA réunit données normalisées, modélisation de procédés, évaluation des impacts et revue en équipe dans un même espace de travail. Suivez la documentation par tâche, de la recherche de données à l’interprétation des résultats.',
+    primary: 'Effectuer les premières étapes',
+    secondary: 'Parcourir les guides',
+    pathsEyebrow: 'Guides par tâche',
+    pathsTitle: 'Commencez par la tâche à accomplir',
+    pathsDescription: 'Choisissez une tâche pour accéder directement aux étapes, aux repères d’interface et aux contrôles de résultat.',
+    openGuide: 'Ouvrir le guide',
     paths: [
-      { title: 'Comprendre la plateforme', description: 'Découvrez le rôle, les espaces de données et les fonctions clés de TianGong LCA.', slug: 'overview', accent: 'plum' },
-      { title: 'Démarrer rapidement', description: 'Connectez-vous, trouvez des données et terminez votre premier parcours.', slug: 'quick-start', accent: 'violet' },
-      { title: 'Réaliser une ACV', description: "Suivez des tâches réelles sur les données, modèles, LCIA, révision et travail d'équipe.", slug: 'user-guide', accent: 'amber' },
-      { title: 'Connecter vos outils', description: 'Intégrez les capacités TianGong avec MCP, la CLI et OpenAPI.', slug: 'integration', accent: 'plum' },
+      { title: 'Trouver et utiliser des données', description: 'Recherchez dans les espaces de données, examinez les jeux de données et référencez ou copiez les enregistrements utiles.', slug: 'user-guide/data' },
+      { title: 'Créer des données et des modèles', description: 'Créez des flux et des procédés, reliez les échanges et préparez un modèle calculable.', slug: 'user-guide/create-my-data' },
+      { title: 'Calculer et interpréter l’ACVI', description: 'Lancez l’évaluation des impacts et interprétez les résultats d’un procédé ou d’un modèle.', slug: 'user-guide/lcia' },
+      { title: 'Réviser et collaborer', description: 'Soumettez des données à révision, traitez les retours et travaillez dans les espaces d’équipe.', slug: 'user-guide/data-review' },
     ],
-    closingTitle: 'Vous cherchez le chemin le plus court ?',
-    closingDescription: 'Le démarrage rapide présente les espaces de données, la recherche et les commandes essentielles en dix minutes environ.',
-    closingAction: 'Ouvrir le démarrage rapide',
+    technicalLabel: 'Pour les équipes techniques',
+    integrationAction: 'Connecter MCP, la CLI et OpenAPI',
+    deploymentAction: 'Voir l’auto-hébergement et le développement',
+    conceptMap: {
+      ariaLabel: 'Carte conceptuelle de l’ACV : les données de référence relient les relations entre procédés au système de produit et aux résultats d’ACVI.',
+      referenceLabel: 'Données de référence',
+      referenceItems: ['Données de procédé', 'Flux élémentaires', 'Méthodes d’impact'],
+      relationsLabel: 'Relations de procédé',
+      relationItems: ['Matière', 'Électricité', 'Fabrication'],
+      productSystemLabel: 'Système de produit',
+      resultsLabel: 'Résultats ACVI',
+      impactLabels: ['Changement climatique', 'Ressources'],
+    },
   },
 };
 
@@ -126,75 +171,81 @@ export function DocsHome({ lang }: { lang: string }) {
 
   return (
     <HomeLayout {...baseOptions(language)}>
-      <main className="atlas-home">
-        <section className="atlas-hero">
-          <div className="atlas-shell atlas-hero-grid">
-            <div className="atlas-hero-copy">
-              <p className="atlas-eyebrow">{content.eyebrow}</p>
-              <h1>{content.title}</h1>
-              <p className="atlas-lede">{content.description}</p>
-              <div className="atlas-actions">
-                <Link className="atlas-button atlas-button-primary" href={`/${language}/docs/quick-start/`}>
+      <div className="min-w-0 max-w-full flex-1 overflow-clip text-fd-foreground">
+        <section className="border-b border-fd-border bg-fd-background" data-hero-signature="lca-concept-map">
+          <div className="atlas-shell grid min-h-[40rem] grid-cols-[minmax(0,5fr)_minmax(31rem,7fr)] items-center gap-[clamp(2.5rem,5vw,5rem)] py-[clamp(4.5rem,8vw,7rem)] max-[68rem]:grid-cols-1 max-[40rem]:min-h-0 max-[40rem]:gap-12 max-[40rem]:py-12">
+            <div className="min-w-0 max-w-[38rem] max-[68rem]:max-w-[48rem]">
+              <p className="docs-eyebrow">{content.eyebrow}</p>
+              <h1 className="m-0 max-w-[14ch] text-[clamp(2.5rem,4.5vw,4.25rem)] leading-[1.08] font-[560] tracking-[-0.045em] text-balance max-[40rem]:max-w-full max-[40rem]:text-[clamp(2.25rem,10vw,3rem)] max-[40rem]:tracking-[-0.04em]">
+                {content.title}
+              </h1>
+              <p className="mt-6 mb-0 max-w-[39rem] text-[clamp(1rem,1.35vw,1.125rem)] leading-[1.7] text-fd-muted-foreground">
+                {content.description}
+              </p>
+              <div className="mt-8 flex flex-wrap gap-2 max-[40rem]:flex-col max-[40rem]:items-stretch">
+                <Link
+                  className={`${buttonVariants({ variant: 'primary' })} min-h-12 min-w-[11.5rem] justify-between rounded-[2px] px-4 py-3 text-sm font-medium transition-colors duration-100 hover:bg-[#481c53] active:bg-[#35123e] dark:hover:bg-[#dabdff] dark:active:bg-[#eadbff] max-[40rem]:w-full`}
+                  data-primary-action
+                  href={`/${language}/docs/quick-start/`}
+                >
                   {content.primary}
                   <Arrow />
                 </Link>
-                <Link className="atlas-button atlas-button-secondary" href={`/${language}/docs/user-guide/`}>
+                <Link
+                  className={`${buttonVariants({ variant: 'outline' })} min-h-12 min-w-[11.5rem] justify-between rounded-[2px] border-fd-border bg-transparent px-4 py-3 text-sm font-medium transition-colors duration-100 max-[40rem]:w-full`}
+                  href={`/${language}/docs/user-guide/`}
+                >
                   {content.secondary}
                 </Link>
               </div>
             </div>
 
-            <div className="atlas-map" role="img" aria-label={content.mapLabel}>
-              <div className="atlas-map-grid" aria-hidden="true" />
-              <div className="atlas-orbit atlas-orbit-one" aria-hidden="true" />
-              <div className="atlas-orbit atlas-orbit-two" aria-hidden="true" />
-              <div className="atlas-map-core" aria-hidden="true">
-                <span>Data</span>
-                <strong>Atlas</strong>
-              </div>
-              {content.mapNodes.map((node, index) => (
-                <div className={`atlas-map-node atlas-map-node-${index + 1}`} key={node} aria-hidden="true">
-                  <span>{String(index + 1).padStart(2, '0')}</span>
-                  {node}
-                </div>
-              ))}
-            </div>
+            <LcaConceptMap copy={content.conceptMap} />
           </div>
         </section>
 
-        <section className="atlas-paths">
+        <section className="bg-fd-background py-[clamp(4.5rem,8vw,7rem)]">
           <div className="atlas-shell">
-            <div className="atlas-section-heading">
-              <p className="atlas-eyebrow">{content.pathsEyebrow}</p>
-              <h2>{content.pathsTitle}</h2>
-              <p>{content.pathsDescription}</p>
+            <div className="mb-10 grid max-w-[48rem] gap-2.5">
+              <p className="docs-eyebrow">{content.pathsEyebrow}</p>
+              <h2 className="m-0 text-[clamp(2rem,3.5vw,3rem)] leading-[1.12] font-[520] tracking-[-0.035em] text-balance">
+                {content.pathsTitle}
+              </h2>
+              <p className="m-0 text-base leading-[1.65] text-fd-muted-foreground">{content.pathsDescription}</p>
             </div>
-            <div className="atlas-path-grid">
+            <Cards className="grid-cols-4 gap-3 max-[68rem]:grid-cols-2 max-[40rem]:grid-cols-1">
               {content.paths.map((path) => (
-                <Link className={`atlas-path-card atlas-accent-${path.accent}`} href={`/${language}/docs/${path.slug}/`} key={path.slug}>
-                  <span className="atlas-card-kicker">{path.slug.replace('-', ' ')}</span>
-                  <h3>{path.title}</h3>
-                  <p>{path.description}</p>
-                  <span className="atlas-card-arrow"><Arrow /></span>
-                </Link>
+                <Card
+                  className="grid min-h-56 content-start gap-2.5 rounded-[2px] border-fd-border bg-fd-card p-5 text-inherit transition-colors duration-100 hover:border-fd-primary hover:bg-fd-accent max-[40rem]:min-h-48 [&>div:last-child]:self-end [&_h3]:m-0 [&_h3]:text-lg [&_h3]:leading-[1.35] [&_h3]:font-semibold [&_h3]:tracking-[-0.02em] [&_p]:m-0! [&_p]:text-sm [&_p]:leading-[1.6] [&_p]:text-fd-muted-foreground"
+                  description={path.description}
+                  href={`/${language}/docs/${path.slug}/`}
+                  key={path.slug}
+                  title={path.title}
+                >
+                  <span className="inline-flex items-center gap-2 text-xs font-medium text-fd-primary">
+                    {content.openGuide}
+                    <Arrow />
+                  </span>
+                </Card>
               ))}
-            </div>
-          </div>
-        </section>
+            </Cards>
 
-        <section className="atlas-closing">
-          <div className="atlas-shell atlas-closing-card">
-            <div>
-              <h2>{content.closingTitle}</h2>
-              <p>{content.closingDescription}</p>
+            <div className="mt-12 grid grid-cols-[minmax(11rem,1fr)_minmax(0,3fr)] items-start gap-6 border-t border-fd-border pt-5 max-[40rem]:grid-cols-1">
+              <p className="m-0 text-xs font-semibold tracking-[0.04em] text-fd-muted-foreground uppercase">{content.technicalLabel}</p>
+              <div className="flex flex-wrap gap-x-8 gap-y-3">
+                <Link className="inline-flex items-center gap-2 text-sm font-medium text-fd-primary" href={`/${language}/docs/integration/`}>
+                  {content.integrationAction}
+                  <Arrow />
+                </Link>
+                <Link className="inline-flex items-center gap-2 text-sm font-medium text-fd-primary" href={`/${language}/docs/deploy-and-dev/`}>
+                  {content.deploymentAction}
+                  <Arrow />
+                </Link>
+              </div>
             </div>
-            <Link className="atlas-button atlas-button-primary" href={`/${language}/docs/quick-start/`}>
-              {content.closingAction}
-              <Arrow />
-            </Link>
           </div>
         </section>
-      </main>
+      </div>
     </HomeLayout>
   );
 }

--- a/components/docs-home.tsx
+++ b/components/docs-home.tsx
@@ -16,6 +16,7 @@ interface HomePath {
 interface HomeCopy {
   eyebrow: string;
   title: string;
+  titleLines?: readonly [string, string];
   description: string;
   primary: string;
   secondary: string;
@@ -33,10 +34,11 @@ interface HomeCopy {
 const copy: Record<Language, HomeCopy> = {
   zh: {
     eyebrow: 'TianGong LCA · 开源生命周期评价平台',
-    title: '查找数据、建立模型，完成生命周期评价',
+    title: '从数据到模型，完成生命周期评价',
+    titleLines: ['从数据到模型，', '完成生命周期评价'],
     description:
-      'TianGong LCA 将标准化数据、过程建模、LCIA 计算和团队评审连接在一个工作区。按任务查阅文档，从检索数据开始，直到解释结果。',
-    primary: '完成首次操作',
+      'TianGong LCA 将标准化数据、过程建模、LCIA 计算与团队评审串联起来。文档按真实任务组织，帮助你从查找数据、建立模型一路到理解结果。',
+    primary: '从快速入门开始',
     secondary: '浏览任务指南',
     pathsEyebrow: '任务指南',
     pathsTitle: '从要完成的工作开始',
@@ -53,6 +55,7 @@ const copy: Record<Language, HomeCopy> = {
     deploymentAction: '查看私有部署与开发',
     conceptMap: {
       ariaLabel: '生命周期评价概念图：参考数据连接过程关系，形成产品系统并生成 LCIA 结果。',
+      title: '生命周期评价概念图',
       referenceLabel: '参考数据',
       referenceItems: ['过程数据', '基本流', '影响方法'],
       relationsLabel: '过程关系',
@@ -84,6 +87,7 @@ const copy: Record<Language, HomeCopy> = {
     deploymentAction: 'View self-hosting and development',
     conceptMap: {
       ariaLabel: 'Life cycle assessment concept map: reference data connects process relationships to a product system and LCIA results.',
+      title: 'Life cycle assessment concept map',
       referenceLabel: 'Reference data',
       referenceItems: ['Process data', 'Elementary flows', 'Impact methods'],
       relationsLabel: 'Process relations',
@@ -115,6 +119,7 @@ const copy: Record<Language, HomeCopy> = {
     deploymentAction: 'Self-Hosting und Entwicklung ansehen',
     conceptMap: {
       ariaLabel: 'Konzeptkarte der Ökobilanz: Referenzdaten verbinden Prozessbeziehungen mit dem Produktsystem und den LCIA-Ergebnissen.',
+      title: 'Konzeptkarte der Ökobilanz',
       referenceLabel: 'Referenzdaten',
       referenceItems: ['Prozessdaten', 'Elementarflüsse', 'Wirkungsmethoden'],
       relationsLabel: 'Prozessbeziehungen',
@@ -146,6 +151,7 @@ const copy: Record<Language, HomeCopy> = {
     deploymentAction: 'Voir l’auto-hébergement et le développement',
     conceptMap: {
       ariaLabel: 'Carte conceptuelle de l’ACV : les données de référence relient les relations entre procédés au système de produit et aux résultats d’ACVI.',
+      title: 'Carte conceptuelle de l’ACV',
       referenceLabel: 'Données de référence',
       referenceItems: ['Données de procédé', 'Flux élémentaires', 'Méthodes d’impact'],
       relationsLabel: 'Relations de procédé',
@@ -176,8 +182,10 @@ export function DocsHome({ lang }: { lang: string }) {
           <div className="atlas-shell grid min-h-[40rem] grid-cols-[minmax(0,5fr)_minmax(31rem,7fr)] items-center gap-[clamp(2.5rem,5vw,5rem)] py-[clamp(4.5rem,8vw,7rem)] max-[68rem]:grid-cols-1 max-[40rem]:min-h-0 max-[40rem]:gap-12 max-[40rem]:py-12">
             <div className="min-w-0 max-w-[38rem] max-[68rem]:max-w-[48rem]">
               <p className="docs-eyebrow">{content.eyebrow}</p>
-              <h1 className="m-0 max-w-[14ch] text-[clamp(2.5rem,4.5vw,4.25rem)] leading-[1.08] font-[560] tracking-[-0.045em] text-balance max-[40rem]:max-w-full max-[40rem]:text-[clamp(2.25rem,10vw,3rem)] max-[40rem]:tracking-[-0.04em]">
-                {content.title}
+              <h1 className="m-0 max-w-[14ch] text-[clamp(2.5rem,4.5vw,4.25rem)] leading-[1.08] font-[560] tracking-[-0.045em] text-balance max-[40rem]:max-w-full max-[40rem]:text-[clamp(2.2rem,10vw,2.8rem)] max-[40rem]:tracking-[-0.04em]">
+                {content.titleLines
+                  ? content.titleLines.map((line) => <span className="block whitespace-nowrap" key={line}>{line}</span>)
+                  : content.title}
               </h1>
               <p className="mt-6 mb-0 max-w-[39rem] text-[clamp(1rem,1.35vw,1.125rem)] leading-[1.7] text-fd-muted-foreground">
                 {content.description}

--- a/components/docs-home.tsx
+++ b/components/docs-home.tsx
@@ -182,9 +182,9 @@ export function DocsHome({ lang }: { lang: string }) {
           <div className="atlas-shell grid min-h-[40rem] grid-cols-[minmax(0,5fr)_minmax(31rem,7fr)] items-center gap-[clamp(2.5rem,5vw,5rem)] py-[clamp(4.5rem,8vw,7rem)] max-[68rem]:grid-cols-1 max-[40rem]:min-h-0 max-[40rem]:gap-12 max-[40rem]:py-12">
             <div className="min-w-0 max-w-[38rem] max-[68rem]:max-w-[48rem]">
               <p className="docs-eyebrow">{content.eyebrow}</p>
-              <h1 className="m-0 max-w-[14ch] text-[clamp(2.5rem,4.5vw,4.25rem)] leading-[1.08] font-[560] tracking-[-0.045em] text-balance max-[40rem]:max-w-full max-[40rem]:text-[clamp(2.2rem,10vw,2.8rem)] max-[40rem]:tracking-[-0.04em]">
+              <h1 className="m-0 max-w-[14ch] text-[clamp(2.5rem,4.5vw,4.25rem)] leading-[1.08] font-[560] tracking-[-0.045em] text-balance max-[40rem]:max-w-full max-[40rem]:text-[clamp(2.2rem,10vw,2.8rem)] max-[40rem]:tracking-[-0.04em]" data-controlled-title>
                 {content.titleLines
-                  ? content.titleLines.map((line) => <span className="block whitespace-nowrap" key={line}>{line}</span>)
+                  ? content.titleLines.map((line) => <span className="block whitespace-nowrap" data-title-line key={line}>{line}</span>)
                   : content.title}
               </h1>
               <p className="mt-6 mb-0 max-w-[39rem] text-[clamp(1rem,1.35vw,1.125rem)] leading-[1.7] text-fd-muted-foreground">

--- a/components/lca-concept-map.tsx
+++ b/components/lca-concept-map.tsx
@@ -1,0 +1,75 @@
+export interface ConceptMapCopy {
+  ariaLabel: string;
+  referenceLabel: string;
+  referenceItems: [string, string, string];
+  relationsLabel: string;
+  relationItems: [string, string, string];
+  productSystemLabel: string;
+  resultsLabel: string;
+  impactLabels: [string, string];
+}
+
+const conceptNode = 'rounded-[2px] border border-fd-border bg-fd-background px-2 py-2 text-center text-[0.625rem] leading-tight font-medium';
+
+function FlowArrow() {
+  return (
+    <svg className="h-4 w-6 shrink-0 text-fd-muted-foreground max-[40rem]:rotate-90" viewBox="0 0 24 16" aria-hidden="true">
+      <path d="M1 8h20m-5-5 5 5-5 5" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export function LcaConceptMap({ copy }: { copy: ConceptMapCopy }) {
+  return (
+    <figure
+      className="m-0 w-full max-w-[43rem] justify-self-end rounded-[4px] border border-fd-border bg-fd-card p-6 max-[68rem]:max-w-none max-[68rem]:justify-self-stretch max-[40rem]:p-4"
+      role="img"
+      aria-label={copy.ariaLabel}
+    >
+      <div className="flex min-h-[20rem] items-center justify-between gap-3 max-[40rem]:min-h-0 max-[40rem]:flex-col" aria-hidden="true">
+        <section className="grid min-w-0 flex-1 gap-3">
+          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] text-fd-muted-foreground uppercase">{copy.referenceLabel}</p>
+          <div className="grid gap-2">
+            {copy.referenceItems.map((item) => <span className={conceptNode} key={item}>{item}</span>)}
+          </div>
+        </section>
+
+        <FlowArrow />
+
+        <section className="grid min-w-0 flex-[1.35] gap-3">
+          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] text-fd-muted-foreground uppercase">{copy.relationsLabel}</p>
+          <div className="grid grid-cols-2 gap-2">
+            <span className={conceptNode}>{copy.relationItems[0]}</span>
+            <span className={`${conceptNode} row-span-2 flex items-center justify-center border-fd-primary bg-fd-accent`}>{copy.relationItems[2]}</span>
+            <span className={conceptNode}>{copy.relationItems[1]}</span>
+          </div>
+        </section>
+
+        <FlowArrow />
+
+        <section className="grid min-w-0 flex-1 gap-3">
+          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] text-fd-muted-foreground uppercase">{copy.productSystemLabel}</p>
+          <div className="flex min-h-24 items-center justify-center rounded-[2px] border border-fd-primary bg-fd-accent px-3 text-center text-xs font-semibold">
+            {copy.productSystemLabel}
+          </div>
+        </section>
+
+        <FlowArrow />
+
+        <section className="grid min-w-0 flex-1 gap-3">
+          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] text-fd-muted-foreground uppercase">{copy.resultsLabel}</p>
+          <div className="grid gap-4">
+            {copy.impactLabels.map((label, index) => (
+              <div className="grid gap-2" key={label}>
+                <span className="overflow-hidden text-ellipsis whitespace-nowrap text-[0.625rem] text-fd-muted-foreground">{label}</span>
+                <i className="relative block h-1 bg-fd-border">
+                  <span className={`absolute inset-y-0 start-0 bg-fd-primary ${index === 0 ? 'w-3/4' : 'w-1/2'}`} />
+                </i>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </figure>
+  );
+}

--- a/components/lca-concept-map.tsx
+++ b/components/lca-concept-map.tsx
@@ -1,5 +1,6 @@
 export interface ConceptMapCopy {
   ariaLabel: string;
+  title: string;
   referenceLabel: string;
   referenceItems: [string, string, string];
   relationsLabel: string;
@@ -9,15 +10,7 @@ export interface ConceptMapCopy {
   impactLabels: [string, string];
 }
 
-const conceptNode = 'rounded-[2px] border border-fd-border bg-fd-background px-2 py-2 text-center text-[0.625rem] leading-tight font-medium';
-
-function FlowArrow() {
-  return (
-    <svg className="h-4 w-6 shrink-0 text-fd-muted-foreground max-[40rem]:rotate-90" viewBox="0 0 24 16" aria-hidden="true">
-      <path d="M1 8h20m-5-5 5 5-5 5" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
+const conceptItem = 'text-[0.6875rem] leading-[1.45] text-fd-muted-foreground';
 
 export function LcaConceptMap({ copy }: { copy: ConceptMapCopy }) {
   return (
@@ -26,38 +19,39 @@ export function LcaConceptMap({ copy }: { copy: ConceptMapCopy }) {
       role="img"
       aria-label={copy.ariaLabel}
     >
-      <div className="flex min-h-[20rem] items-center justify-between gap-3 max-[40rem]:min-h-0 max-[40rem]:flex-col" aria-hidden="true">
-        <section className="grid min-w-0 flex-1 gap-3">
-          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] text-fd-muted-foreground uppercase">{copy.referenceLabel}</p>
-          <div className="grid gap-2">
-            {copy.referenceItems.map((item) => <span className={conceptNode} key={item}>{item}</span>)}
+      <figcaption className="m-0 text-[0.6875rem] font-semibold tracking-[0.08em] text-fd-primary uppercase" aria-hidden="true">
+        {copy.title}
+      </figcaption>
+
+      <div className="relative mt-4 grid min-h-[19rem] grid-cols-[minmax(0,1.05fr)_minmax(7.5rem,0.72fr)_minmax(0,1fr)] grid-rows-2 gap-x-10 gap-y-4 max-[40rem]:min-h-0 max-[40rem]:grid-cols-1 max-[40rem]:grid-rows-none max-[40rem]:gap-3" aria-hidden="true">
+        <svg className="pointer-events-none absolute inset-0 h-full w-full text-fd-border max-[40rem]:hidden" preserveAspectRatio="none" viewBox="0 0 100 100">
+          <path d="M30 25 L43 50 M30 75 L43 50 M57 50 L72 50" fill="none" stroke="currentColor" strokeWidth="0.55" vectorEffect="non-scaling-stroke" />
+          <circle cx="43" cy="50" r="1.1" fill="var(--color-fd-primary)" />
+          <circle cx="57" cy="50" r="1.1" fill="var(--color-fd-primary)" />
+        </svg>
+
+        <section className="relative z-10 grid min-w-0 content-center gap-3 rounded-[2px] border border-fd-border bg-fd-background p-4">
+          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] uppercase">{copy.referenceLabel}</p>
+          <div className="grid gap-1.5">
+            {copy.referenceItems.map((item) => <span className={conceptItem} key={item}>{item}</span>)}
           </div>
         </section>
 
-        <FlowArrow />
-
-        <section className="grid min-w-0 flex-[1.35] gap-3">
-          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] text-fd-muted-foreground uppercase">{copy.relationsLabel}</p>
-          <div className="grid grid-cols-2 gap-2">
-            <span className={conceptNode}>{copy.relationItems[0]}</span>
-            <span className={`${conceptNode} row-span-2 flex items-center justify-center border-fd-primary bg-fd-accent`}>{copy.relationItems[2]}</span>
-            <span className={conceptNode}>{copy.relationItems[1]}</span>
+        <section className="relative z-10 row-start-2 grid min-w-0 content-center gap-3 rounded-[2px] border border-fd-border bg-fd-background p-4 max-[40rem]:row-auto">
+          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] uppercase">{copy.relationsLabel}</p>
+          <div className="flex flex-wrap gap-x-3 gap-y-1.5">
+            {copy.relationItems.map((item) => <span className={conceptItem} key={item}>{item}</span>)}
           </div>
         </section>
 
-        <FlowArrow />
-
-        <section className="grid min-w-0 flex-1 gap-3">
-          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] text-fd-muted-foreground uppercase">{copy.productSystemLabel}</p>
-          <div className="flex min-h-24 items-center justify-center rounded-[2px] border border-fd-primary bg-fd-accent px-3 text-center text-xs font-semibold">
+        <section className="relative z-10 col-start-2 row-span-2 flex min-w-0 items-center max-[40rem]:col-auto max-[40rem]:row-auto">
+          <div className="flex min-h-32 w-full items-center justify-center rounded-[2px] border border-fd-primary bg-fd-accent px-3 text-center text-xs font-semibold max-[40rem]:min-h-24">
             {copy.productSystemLabel}
           </div>
         </section>
 
-        <FlowArrow />
-
-        <section className="grid min-w-0 flex-1 gap-3">
-          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] text-fd-muted-foreground uppercase">{copy.resultsLabel}</p>
+        <section className="relative z-10 col-start-3 row-span-2 grid min-w-0 content-center gap-4 rounded-[2px] border border-fd-border bg-fd-background p-4 max-[40rem]:col-auto max-[40rem]:row-auto">
+          <p className="m-0 text-[0.6875rem] font-semibold tracking-[0.06em] uppercase">{copy.resultsLabel}</p>
           <div className="grid gap-4">
             {copy.impactLabels.map((label, index) => (
               <div className="grid gap-2" key={label}>

--- a/components/site-brand.tsx
+++ b/components/site-brand.tsx
@@ -8,7 +8,8 @@ export function SiteBrand() {
         <img src="/logo-dark.svg" alt="" width={28} height={28} className="hidden dark:block" />
       </span>
       <span className="atlas-brand-name">
-        TianGong LCA <span className="atlas-brand-product">Docs</span>
+        TianGong LCA <span className="atlas-brand-divider" aria-hidden="true">/</span>{' '}
+        <span className="atlas-brand-product">Documentation</span>
       </span>
     </span>
   );

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -7,7 +7,7 @@ authoritative: true
 owner: next-docs
 language: en
 whenToUse:
-  - when changing routing, locale behavior, content loading, search, metadata, or the Data Atlas presentation
+  - when changing routing, locale behavior, content loading, search, metadata, or the documentation presentation
   - when checking boundaries between public documentation and shipped product behavior
 whenToUpdate:
   - when public-site structure, locale policy, publishing, or output contracts change
@@ -31,8 +31,8 @@ checkPaths:
   - context7.json
   - .github/workflows/**
 lastReviewedAt: "2026-08-23"
-lastReviewedCommit: d4f91b9c1d5a1e37f212da006a7ee75a1555c456
-lastReviewedNote: "Reviewed for Issue #136 after shared Data Atlas UI, locale-aware metadata, generated link validation, and greenfield cleanup."
+lastReviewedCommit: 88952727c75ac491473cb9dc295651a1fc0b165d
+lastReviewedNote: "Reviewed for Issue #140 after the landing moved to Fumadocs Neutral primitives, a flat shared shell, and a Next-specific LCA concept map."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -55,17 +55,18 @@ Retired paths are intentionally absent. No application or hosting configuration 
 
 ## Presentation
 
-`components/SiteBrand` and `components/DocsHome` are the shared Data Atlas UI entry points. `lib/layout.shared.tsx` supplies the same brand, search, theme, language, documentation, and repository controls to `HomeLayout` and `DocsLayout`.
+`components/SiteBrand` and `components/DocsHome` are the shared shell entry points. `lib/layout.shared.tsx` supplies the same brand, search, theme, language, documentation, and repository controls to `HomeLayout` and `DocsLayout`. The landing reuses Fumadocs `buttonVariants`, `Card`, and `Cards`; it does not maintain parallel button or card primitives.
 
 `app/global.css` owns the shared contract:
 
-- explicit centered shell widths and responsive gutters;
-- TianGong plum, bright violet, and amber tokens;
+- an explicit centered 72rem shell and responsive gutters;
+- neutral Carbon-style layers with the original TianGong plum retained as a solid interaction color;
 - light/dark behavior and visible keyboard focus;
-- logo plus `TianGong LCA Docs` brand lockup;
-- responsive home grid and mobile-safe document pagination.
+- logo plus `TianGong LCA / Documentation` brand lockup;
+- low-radius, border-defined controls without gradients, glow, shadow, or lift animation;
+- mobile-safe document pagination.
 
-Site-specific content can change, but shell widths, control placement, brand treatment, and accessibility behavior should stay aligned with the TIDAS documentation site.
+`components/lca-concept-map.tsx` owns the TianGong LCA hero signature. Its abstract reference-data → process-relations → product-system → LCIA-results topology is intentionally different from the TIDAS data-system/schema signature. The `data-hero-signature="lca-concept-map"` marker makes that distinction testable while shell widths, control placement, brand treatment, and accessibility behavior remain aligned between the sites.
 
 ## Content and locales
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/**
   - .githooks/**
 lastReviewedAt: "2026-08-23"
-lastReviewedCommit: d4f91b9c1d5a1e37f212da006a7ee75a1555c456
-lastReviewedNote: "Reviewed for Issue #136 after permanent generated-link validation and Data Atlas browser QA were added to the delivery proof."
+lastReviewedCommit: 88952727c75ac491473cb9dc295651a1fc0b165d
+lastReviewedNote: "Reviewed for Issue #140 after browser proof and stable DOM markers were defined for the flat primary action and LCA concept-map landing."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -56,6 +56,7 @@ DEPLOY_ENV=ci CANONICAL_ORIGIN=http://localhost:3000 NEXT_PUBLIC_SEARCH_MODE=sta
 - Public content: update all four locale variants; run lint and the complete build.
 - Links, anchors, navigation, or assets: run link unit tests and the complete build. `check:links` must report zero missing pages, fragments, or local assets.
 - Layout, CSS, brand, search dialog, or responsive behavior: run typecheck and build, then inspect a real browser at 390px, 1440px, and an ultra-wide viewport in light and dark themes. Confirm keyboard focus, language switching, search, mobile menu, and zero horizontal overflow.
+- Landing visual contract: assert `data-hero-signature="lca-concept-map"`, exactly one `data-primary-action`, and a single semantic HTML `main`. The primary action must compute to `background-image: none`, `box-shadow: none`, and `transform: none`; the Next signature must not match the TIDAS hero signature.
 - Metadata or route changes: inspect generated HTML for canonical, `x-default`, all real locale alternatives, and Open Graph image metadata; confirm sitemap entries and negative 404 contracts.
 - Production publishing or search reconciliation: run the complete build, verify deployed `/llms.txt` and `/search-records.json` expose the expected SHA, assert indexable robots/canonical metadata, then confirm locale-isolated Algolia search.
 - Preview reconciliation: assert the same deployed SHA but require `Disallow: /`, page `noindex`, and production-origin canonical/sitemap URLs; confirm the production-state job is skipped.


### PR DESCRIPTION
## Summary

- Replace the shared orbit/poster landing with a restrained Fumadocs Neutral surface and the established solid TianGong purple primary.
- Present TianGong LCA through a product-system-centred **lifecycle-assessment concept map** instead of a workbench, workflow view, or fake application chrome.
- Rewrite all four locale landings around reader tasks and reuse Fumadocs buttons and cards.
- Align the shell, navigation brand lockup, spacing, action hierarchy, dark theme, and documentation governance with the shared workspace contract.

## Key decisions

- Public thesis: `从数据到模型，完成生命周期评价`.
- Concept relationship: reference data and process relationships inform the product system, which produces LCIA results.
- No gradient, glow, decorative shadow, orbit, continuous motion, or poster-sized heading.
- No compatibility redirects or retired landing UI.

## Validation

- `pnpm lint`: 197 files, 0 issues.
- `pnpm typecheck`: passed.
- CI-mode build: 396 static routes; 17/17 output checks; 12,448 local link/media references across 200 HTML files resolved.
- Docpact enforce: 10 matched rules, 0 findings, 0 uncovered paths, 0 invalid review references.
- Browser visual proof: light/dark at 390, 1440, and 2560 widths; centered shell, one `main`, no overflow, no clipped title lines, no console errors; solid primary with no gradient/shadow/transform.

## Delivery

- EdgeOne publication remains owned by the existing main-branch CI.
- Workspace integration is required after merge so the root submodule pointer and shared design contract can be synchronized.

Closes #140
